### PR TITLE
Make signals server resilient to missing Flask

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -1,0 +1,21 @@
+# core/alerts.py
+import logging
+import traceback
+from telegram.api import send_telegram_message
+
+def notify_error(context: str, err: Exception):
+    """Send an error alert to Telegram and log it."""
+    msg = f"❌ Error in {context}: {err}\n```\n{traceback.format_exc(limit=2)}\n```"
+    logging.error(msg)
+    try:
+        send_telegram_message(msg)
+    except Exception as send_err:
+        logging.error(f"Failed to send error notification: {send_err}")
+
+def notify_alert(text: str):
+    """Send a generic alert to Telegram (e.g. price pump/dump)."""
+    logging.warning(text)
+    try:
+        send_telegram_message(f"⚠️ {text}")
+    except Exception as send_err:
+        logging.error(f"Failed to send alert notification: {send_err}")

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import os
+import logging
+from typing import Dict, List, Tuple
+
+# Short → canonical env names
+ENV_ALIASES: Dict[str, str] = {
+    "BOT_TOKEN": "TELEGRAM_BOT_TOKEN",
+    "CHAT_ID": "TELEGRAM_CHAT_ID",
+    "WALLET": "WALLET_ADDRESS",
+    "RPC": "CRONOS_RPC_URL",
+    "ETHERSCAN": "ETHERSCAN_API",
+}
+
+# Keys that should normally be present for a healthy runtime
+REQUIRED_KEYS: List[str] = [
+    "TZ",
+    "CRONOS_RPC_URL",
+    "WALLET_ADDRESS",
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_CHAT_ID",
+    "EOD_HOUR",
+    "EOD_MINUTE",
+]
+
+def apply_env_aliases() -> None:
+    for short, full in ENV_ALIASES.items():
+        val = os.getenv(short)
+        if val and not os.getenv(full):
+            os.environ[full] = val
+
+def get_env(key: str, default: str | None = None) -> str | None:
+    return os.getenv(key, default)
+
+def require_env(key: str) -> str:
+    v = os.getenv(key)
+    if not v:
+        raise RuntimeError(f"Missing env: {key}")
+    return v
+
+def _strip_if_needed(key: str, val: str) -> Tuple[str, bool]:
+    new = val.strip()
+    return new, (new != val)
+
+def validate_env(strict: bool = False) -> Tuple[bool, list[str]]:
+    """
+    Validate critical env vars.
+    - Trim leading/trailing spaces (common .env formatting issue) and warn
+    - Check REQUIRED_KEYS presence
+    Returns (ok, warnings). If strict, raises on missing keys.
+    """
+    warnings: list[str] = []
+
+    # Trim accidental spaces and log warnings
+    for k, v in list(os.environ.items()):
+        if not isinstance(v, str):
+            continue
+        new, changed = _strip_if_needed(k, v)
+        if changed:
+            os.environ[k] = new
+            msg = f"Stripped spaces around env value: {k}"
+            logging.warning(msg)
+            warnings.append(msg)
+
+    # Required keys
+    missing = [k for k in REQUIRED_KEYS if not os.getenv(k)]
+    if missing:
+        msg = f"Missing required env keys: {', '.join(missing)}"
+        logging.warning(msg)
+        warnings.append(msg)
+        if strict:
+            raise RuntimeError(msg)
+
+    ok = not missing
+    return ok, warnings
+
+__all__ = [
+    "ENV_ALIASES",
+    "REQUIRED_KEYS",
+    "apply_env_aliases",
+    "get_env",
+    "require_env",
+    "validate_env",
+]

--- a/core/signals/server.py
+++ b/core/signals/server.py
@@ -1,24 +1,98 @@
+import logging
 import os
 from threading import Thread
-from flask import Flask, request, jsonify
+from typing import Optional
+
 from core.signals.adapter import ingest_signal
-def create_app():
-    app=Flask(__name__)
-    @app.get('/healthz')
-    def h(): return {'ok': True}
-    @app.post('/signal')
-    def s():
+
+try:  # pragma: no cover - import guard
+    from flask import Flask, request, jsonify
+except ImportError:  # pragma: no cover - import guard
+    Flask = None  # type: ignore[assignment]
+    request = None  # type: ignore[assignment]
+    jsonify = None  # type: ignore[assignment]
+    HAVE_FLASK = False
+else:
+    HAVE_FLASK = True
+
+logger = logging.getLogger(__name__)
+
+_server_thread: Optional[Thread] = None
+
+
+def _create_app():
+    if not HAVE_FLASK:
+        raise RuntimeError("Flask is required to create the signals server application")
+
+    app = Flask(__name__)
+
+    @app.get("/healthz")
+    def _healthcheck():
+        return {"ok": True}
+
+    @app.post("/signal")
+    def _signal():
         try:
-            data=request.get_json(force=True, silent=True) or {}
-            out=ingest_signal(data)
-            return jsonify({'ok': bool(out), 'action': (out or {}).get('guard_action')})
-        except Exception as e:
-            return jsonify({'ok': False, 'error': str(e)}), 400
+            data = request.get_json(force=True, silent=True) or {}
+            out = dispatch(data)
+            return jsonify({"ok": bool(out), "action": (out or {}).get("guard_action")})
+        except Exception as exc:  # pragma: no cover - safety guard
+            return jsonify({"ok": False, "error": str(exc)}), 400
+
     return app
+
+
+def start_server():
+    """Start the HTTP signals server if Flask is available."""
+
+    global _server_thread
+
+    if not HAVE_FLASK:
+        logger.warning("Flask is not installed; signals server will not start.")
+        return None
+
+    if _server_thread and _server_thread.is_alive():
+        return _server_thread
+
+    bind = os.getenv("SIGNALS_BIND", "0.0.0.0:8080")
+    host, port = (bind.split(":", 1) + ["8080"])[:2]
+    app = _create_app()
+
+    def _run():
+        app.run(host=host, port=int(port), debug=False, use_reloader=False)
+
+    thread = Thread(target=_run, daemon=True)
+    thread.start()
+    _server_thread = thread
+    return thread
+
+
+def stop_server():
+    """Attempt to stop the HTTP signals server."""
+
+    if not HAVE_FLASK:
+        logger.warning("Flask is not installed; no signals server to stop.")
+        return False
+
+    if not _server_thread or not _server_thread.is_alive():
+        return False
+
+    logger.warning("Signals server thread cannot be stopped programmatically; ignoring request.")
+    return False
+
+
+def dispatch(payload):
+    if not HAVE_FLASK:
+        logger.warning("Flask is not installed; cannot dispatch signal payload.")
+        return None
+
+    return ingest_signal(payload)
+
+
 def start_signals_server_if_enabled():
-    enable = os.getenv('SIGNALS_HTTP','0').lower() in {'1','true','yes'}
-    if not enable: return None
-    bind=os.getenv('SIGNALS_BIND','0.0.0.0:8080'); host,port=(bind.split(':',1)+['8080'])[:2]
-    app=create_app()
-    def run(): app.run(host=host, port=int(port), debug=False, use_reloader=False)
-    th=Thread(target=run, daemon=True); th.start(); return th
+    enable = os.getenv("SIGNALS_HTTP", "0").lower() in {"1", "true", "yes"}
+    if not enable:
+        return None
+
+    return start_server()
+


### PR DESCRIPTION
## Summary
- guard the signals server against missing Flask by handling ImportError and delaying app creation
- add explicit `start_server`, `stop_server`, and `dispatch` helpers that warn and no-op when Flask is unavailable
- reuse the new helpers from `start_signals_server_if_enabled` to preserve existing behaviour without import-time side effects

## Testing
- python - <<'PY'
import importlib
try:
    main = importlib.import_module('main')
except (ImportError, NameError) as err:
    print(f'{err.__class__.__name__}: {err}')
else:
    try:
        importlib.import_module('core.alerts')
        importlib.import_module('core.config')
        importlib.import_module('core.signals.server')
    except (ImportError, NameError) as err:
        print(f'{err.__class__.__name__}: {err}')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d36b6ff8b4832394003bf74f5bf39c