### PR TITLE
fix: robust Cronos tx parsing (guard non-dict items)

### DIFF
--- a/core/providers/cronos.py
+++ b/core/providers/cronos.py
@@ -1,34 +1,90 @@
 from __future__ import annotations
-from typing import List, Dict
+from typing import Dict, List, Any
 from decimal import Decimal
 from core.providers.etherscan_like import account_txlist, account_tokentx
 
 def _D(x): return Decimal(str(x or 0))
 
+def _safe_json(data: Any) -> Dict[str, object]:
+    return data if isinstance(data, dict) else {}
+
+def _int(value) -> int:
+    try:
+        if value is None:
+            return 0
+        return int(str(value))
+    except (TypeError, ValueError):
+        return 0
+
 def fetch_wallet_txs(address: str) -> List[Dict[str, object]]:
-    txs = (account_txlist(address) or {}).get("result") or []
-    toks = (account_tokentx(address) or {}).get("result") or []
-    by_hash = {}
+    tx_resp = _safe_json(account_txlist(address)) or {}
+    txs = tx_resp.get("result") or tx_resp.get("txs") or []
+    if not isinstance(txs, list):
+        txs = []
+
+    tok_resp = _safe_json(account_tokentx(address)) or {}
+    toks = tok_resp.get("result") or tok_resp.get("txs") or []
+    if not isinstance(toks, list):
+        toks = []
+
+    by_hash: Dict[str, List[Dict[str, object]]] = {}
     for t in toks:
+        if not isinstance(t, dict):
+            continue
         by_hash.setdefault(t.get("hash"), []).append(t)
-    out = []
+
+    out: List[Dict[str, object]] = []
+    addr_lower = address.lower()
     for tx in txs:
-        h=tx.get("hash")
-        xfers = by_hash.get(h, [])
+        if not isinstance(tx, dict):
+            continue
+        h = tx.get("hash")
+        xfers = [tr for tr in by_hash.get(h, []) if isinstance(tr, dict)]
+        timestamp = _int(tx.get("timeStamp"))
         if xfers:
-            legs = []
+            legs: List[Dict[str, object]] = []
             for tr in xfers:
-                amt = _D(tr.get("value")) / (Decimal(10) ** int(tr.get("tokenDecimal") or 18))
+                try:
+                    decimals = int(tr.get("tokenDecimal") or 18)
+                except (TypeError, ValueError):
+                    decimals = 18
+                if decimals < 0:
+                    decimals = 0
+                amt = _D(tr.get("value")) / (Decimal(10) ** decimals)
                 sym = (tr.get("tokenSymbol") or "?").upper()
-                side = "IN" if (tr.get("to","") or "").lower()==address.lower() else "OUT"
-                legs.append({"side":side, "asset":sym, "qty": str(amt), "price_usd": None, "usd": None})
-            if any(l["side"]=="IN" for l in legs) and any(l["side"]=="OUT" for l in legs):
-                out.append({"txid":h, "time": int(tx.get("timeStamp") or 0), "side":"SWAP", "legs":legs})
+                to_addr = (tr.get("to") or "").lower()
+                side = "IN" if to_addr == addr_lower else "OUT"
+                legs.append({
+                    "side": side,
+                    "asset": sym,
+                    "qty": str(amt),
+                    "price_usd": None,
+                    "usd": None,
+                })
+            if any(l.get("side") == "IN" for l in legs) and any(l.get("side") == "OUT" for l in legs):
+                out.append({"txid": h, "time": timestamp, "side": "SWAP", "legs": legs})
                 continue
             for l in legs:
-                out.append({"txid":h, "time": int(tx.get("timeStamp") or 0), "side":l["side"], "asset":l["asset"], "qty": l["qty"], "price_usd": None, "usd": None})
+                out.append({
+                    "txid": h,
+                    "time": timestamp,
+                    "side": l.get("side"),
+                    "asset": l.get("asset"),
+                    "qty": l.get("qty"),
+                    "price_usd": None,
+                    "usd": None,
+                })
         else:
-            val = _D(tx.get("value")) / Decimal(10) ** 18
-            side = "IN" if (tx.get("to","") or "").lower()==address.lower() else "OUT"
-            out.append({"txid":h, "time": int(tx.get("timeStamp") or 0), "side":side, "asset":"CRO", "qty": str(val), "price_usd": None, "usd": None})
-    return out
+            val = _D(tx.get("value")) / (Decimal(10) ** 18)
+            to_addr = (tx.get("to") or "").lower()
+            side = "IN" if to_addr == addr_lower else "OUT"
+            out.append({
+                "txid": h,
+                "time": timestamp,
+                "side": side,
+                "asset": "CRO",
+                "qty": str(val),
+                "price_usd": None,
+                "usd": None,
+            })
+    return [entry for entry in out if isinstance(entry, dict)]


### PR DESCRIPTION
## Summary
- ensure Cronos wallet transaction fetching normalizes API responses before use
- skip non-dict transfer payloads and harden numeric conversions for swaps and transfers
- guarantee `fetch_wallet_txs` always returns dictionaries even when data is malformed

## Testing
- python -m compileall core/providers/cronos.py
- pytest *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68d379bd5254832392f3b36c5b36a0bf