### PR TITLE
feat(runtime): stabilize main loop (EOD, TG loop, throttled errors, health ping) + robust Cronos parsing + Telegram dedupe/plain-text

### DIFF
--- a/core/providers/cronos.py
+++ b/core/providers/cronos.py
@@ -13,7 +13,7 @@ def _coerce_tx_list(data: Any) -> List[Dict[str, object]]:
     resp = safe_json(data) or {}
     txs = resp.get("result") or resp.get("txs") or []
     if not isinstance(txs, list):
-        return []
+        txs = []
     out: List[Dict[str, object]] = []
     for item in txs:
         if isinstance(item, dict):
@@ -34,6 +34,8 @@ def fetch_wallet_txs(address: str) -> List[Dict[str, object]]:
 
     by_hash: Dict[str, List[Dict[str, object]]] = {}
     for t in toks:
+        if not isinstance(t, dict):
+            continue
         by_hash.setdefault(t.get("hash"), []).append(t)
 
     out: List[Dict[str, object]] = []

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
-import os, sys, time, logging, signal, requests
+import os, sys, time, logging, signal, requests, threading
 from dotenv import load_dotenv
-from reports.scheduler import start_eod_scheduler, run_pending
+import schedule
+from reports.scheduler import run_pending
+from reports.day_report import build_day_report_text
 from telegram.api import send_telegram
 try:
     from telegram.api import telegram_long_poll_loop  # new canonical name
@@ -20,6 +22,26 @@ from core.guards import set_holdings
 
 _shutdown=False
 _updates_offset=None
+_last_error_ts=float("-inf")
+
+
+def _env_str(name: str, default: str = "") -> str:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = raw.strip()
+    return value if value else default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logging.debug("invalid float env %s=%r", name, raw)
+        return default
 
 def _setup_logging():
     level=os.getenv("LOG_LEVEL","INFO").upper()
@@ -31,41 +53,82 @@ def _handle(sig, frm):
 
 def _legacy_telegram_long_poll_loop(handler):
     global _updates_offset
-    try:
-        token=os.getenv("TELEGRAM_BOT_TOKEN","").strip()
-        if not token: return
-        url=f"https://api.telegram.org/bot{token}/getUpdates"
-        params={"timeout": 10}
-        if _updates_offset is not None:
-            params["offset"]=_updates_offset
-        r=requests.get(url, params=params, timeout=15)
-        resp=r.json() if r.headers.get("content-type","").startswith("application/json") else {"ok": False}
-        if not resp.get("ok", True):
-            return
-        for upd in resp.get("result", []):
-            _updates_offset = max(_updates_offset or 0, upd.get("update_id", 0) + 1)
-            msg=upd.get("message") or upd.get("edited_message") or {}
-            if not msg:
+    token = _env_str("TELEGRAM_BOT_TOKEN")
+    if not token:
+        return
+    url = f"https://api.telegram.org/bot{token}/getUpdates"
+    params = {"timeout": 10}
+    while not _shutdown:
+        try:
+            if _updates_offset is not None:
+                params["offset"] = _updates_offset
+            r = requests.get(url, params=params, timeout=15)
+            resp = r.json() if r.headers.get("content-type", "").startswith("application/json") else {"ok": False}
+            if not resp.get("ok", True):
                 continue
-            chat_id=(msg.get("chat") or {}).get("id")
-            text=msg.get("text")
-            if not text:
-                continue
-            reply=handler(text, chat_id)
-            if reply:
-                send_telegram(reply)
-    except Exception as e:
-        logging.debug("telegram poll failed: %s", e)
+            for upd in resp.get("result", []):
+                _updates_offset = max(_updates_offset or 0, upd.get("update_id", 0) + 1)
+                msg = upd.get("message") or upd.get("edited_message") or {}
+                if not msg:
+                    continue
+                chat_id = (msg.get("chat") or {}).get("id")
+                text = msg.get("text")
+                if not text:
+                    continue
+                reply = handler(text, chat_id)
+                if reply:
+                    send_telegram(reply)
+        except Exception as e:
+            logging.debug("telegram poll failed: %s", e)
+        time.sleep(1)
 
 
 if telegram_long_poll_loop is None:
     telegram_long_poll_loop = _legacy_telegram_long_poll_loop
 
+def _send_daily_report() -> None:
+    try:
+        report = build_day_report_text(False)
+    except Exception as exc:
+        logging.exception("daily report generation failed: %s", exc)
+        send_telegram("⚠️ Failed to generate daily report.", dedupe=False)
+        return
+    send_telegram("📒 Daily Report\n" + report, dedupe=False)
+
+
+def _send_health_ping() -> None:
+    send_telegram("✅ alive", dedupe=False)
+
+
+def _start_telegram_thread() -> None:
+    if not callable(telegram_long_poll_loop):
+        return
+    tg_thread = threading.Thread(target=telegram_long_poll_loop, args=(dispatch,), daemon=True)
+    tg_thread.start()
+
+
 def main()->int:
+    global _last_error_ts
     load_dotenv(); _setup_logging()
     send_telegram("✅ Cronos DeFi Sentinel started and is online.")
-    try: start_eod_scheduler()
-    except Exception as e: logging.warning("EOD scheduler error: %s", e)
+    eod_time = _env_str("EOD_TIME", "23:59")
+    try:
+        schedule.every().day.at(eod_time).do(_send_daily_report)
+    except schedule.ScheduleValueError as exc:
+        logging.warning("invalid EOD_TIME %s: %s", eod_time, exc)
+    else:
+        logging.info("daily report scheduled at %s", eod_time)
+    health_min = _env_float("HEALTH_MIN", 30.0)
+    if health_min > 0:
+        interval = max(1, int(health_min))
+        try:
+            schedule.every(interval).minutes.do(_send_health_ping)
+        except schedule.ScheduleValueError as exc:
+            logging.warning("health ping schedule error: %s", exc)
+        else:
+            logging.info("health ping scheduled every %s minute(s)", interval)
+    else:
+        logging.info("health ping disabled")
     watcher=make_from_env()
     wallet_mon=make_wallet_monitor(provider=fetch_wallet_txs)
     try: start_signals_server_if_enabled()
@@ -74,6 +137,7 @@ def main()->int:
     holdings_refresh = int(os.getenv("HOLDINGS_REFRESH_SEC","60") or 60); last_hold=0.0
     wallet=os.getenv("WALLET_ADDRESS","")
     poll=int(os.getenv("WALLET_POLL","15") or 15)
+    _start_telegram_thread()
     while not _shutdown:
         t0=time.time()
         try:
@@ -84,9 +148,12 @@ def main()->int:
                 snap=get_wallet_snapshot(wallet) or {}
                 set_holdings(set(snap.keys()))
                 last_hold=time.time()
-            telegram_long_poll_loop(dispatch)
         except Exception as e:
             logging.exception("loop error: %s", e)
+            now = time.monotonic()
+            if now - _last_error_ts >= 120:
+                send_telegram("⚠️ runtime error (throttled)", dedupe=False)
+                _last_error_ts = now
         time.sleep(max(0.5, poll - (time.time()-t0)))
     return 0
 

--- a/telegram/api.py
+++ b/telegram/api.py
@@ -47,7 +47,9 @@ def send_telegram(
     """
     global _last_message_text, _last_message_ts
 
-    if parse_mode == "MarkdownV2":
+    mode = parse_mode or None
+
+    if mode == "MarkdownV2":
         text = escape_md(text)
 
     if dedupe and _last_message_text == text and _last_message_ts is not None:
@@ -64,8 +66,8 @@ def send_telegram(
         "text": text,
         "disable_web_page_preview": True,
     }
-    if parse_mode:
-        payload["parse_mode"] = parse_mode
+    if mode:
+        payload["parse_mode"] = mode
 
     ok, status_code, response = _post(payload)
     if ok:


### PR DESCRIPTION
## Summary
- harden the runtime loop with safe env helpers, background telegram polling, throttled runtime alerts, and scheduled daily/health messages
- make Cronos provider response parsing tolerant to malformed payloads while maintaining dict outputs
- keep Telegram dedupe defaults while ensuring plain text by default unless MarkdownV2 is explicitly requested

## Testing
- python -m compileall main.py


------
https://chatgpt.com/codex/tasks/task_e_68d3893489188323aa3d285401280e70