### PR TITLE
feat: add Telegram reporting suite and schedulers

### DIFF
--- a/core/runtime_state.py
+++ b/core/runtime_state.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import threading
+import time
+from copy import deepcopy
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Optional
+
+_state_lock = threading.Lock()
+_state: Dict[str, Any] = {
+    "last_tick_ts": None,
+    "last_wallet_poll_ts": None,
+    "last_wallet_poll_success": None,
+    "last_rpc_ok_ts": None,
+    "last_rpc_error": None,
+    "snapshot": {},
+    "snapshot_total_usd": Decimal("0"),
+    "snapshot_ts": None,
+    "queue_sizes": {},
+    "last_cost_basis_update": None,
+}
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def update_snapshot(snapshot: Dict[str, Dict[str, Any]], timestamp: Optional[float] = None) -> None:
+    with _state_lock:
+        total = Decimal("0")
+        for item in (snapshot or {}).values():
+            total += _to_decimal(item.get("usd") or item.get("value_usd") or 0)
+        _state["snapshot"] = deepcopy(snapshot or {})
+        _state["snapshot_total_usd"] = total
+        _state["snapshot_ts"] = timestamp or time.time()
+
+
+def get_snapshot() -> Dict[str, Dict[str, Any]]:
+    with _state_lock:
+        return deepcopy(_state.get("snapshot", {}))
+
+
+def note_tick() -> None:
+    with _state_lock:
+        _state["last_tick_ts"] = time.time()
+
+
+def note_wallet_poll(success: bool, error: Optional[str] = None) -> None:
+    with _state_lock:
+        now = time.time()
+        _state["last_wallet_poll_ts"] = now
+        _state["last_wallet_poll_success"] = success
+        if success:
+            _state["last_rpc_ok_ts"] = now
+            _state["last_rpc_error"] = None
+        else:
+            _state["last_rpc_error"] = error or "unknown"
+
+
+def note_cost_basis_update() -> None:
+    with _state_lock:
+        _state["last_cost_basis_update"] = time.time()
+
+
+def set_queue_size(name: str, size: int) -> None:
+    with _state_lock:
+        queues = dict(_state.get("queue_sizes") or {})
+        queues[name] = int(size)
+        _state["queue_sizes"] = queues
+
+
+def get_state() -> Dict[str, Any]:
+    with _state_lock:
+        snapshot_copy = deepcopy(_state.get("snapshot", {}))
+        data = dict(_state)
+        data["snapshot"] = snapshot_copy
+        return data

--- a/core/wallet_monitor.py
+++ b/core/wallet_monitor.py
@@ -1,51 +1,114 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Dict, List
+
 from core.tz import ymd
-from reports.ledger import append_ledger
+from reports.ledger import append_ledger, update_cost_basis
 from core.guards import mark_trade
 from telegram.api import send_telegram_message
-import time
+from core.runtime_state import note_cost_basis_update, note_wallet_poll
+
+
 class WalletMonitor:
-    def __init__(self,wallet,fetch_fn,cooldown_sec=5):
-        self.wallet=wallet; self.fetch_fn=fetch_fn; self.cooldown=cooldown_sec; self._seen=set(); self._last=0
-    def _dedup(self,txs):
-        out=[]; 
-        for e in txs:
-            k=str(e.get('txid') or '')
-            if not k or k in self._seen: continue
-            self._seen.add(k); out.append(e)
+    def __init__(self, wallet: str, fetch_fn, cooldown_sec: int = 5):
+        self.wallet = wallet
+        self.fetch_fn = fetch_fn
+        self.cooldown = cooldown_sec
+        self._seen: set[str] = set()
+        self._last = 0.0
+
+    def _dedup(self, txs: List[Dict[str, object]]):
+        out: List[Dict[str, object]] = []
+        for entry in txs:
+            key = str(entry.get("txid") or "")
+            if not key or key in self._seen:
+                continue
+            self._seen.add(key)
+            out.append(entry)
         return out
-    def _record_alert(self, e):
-        day=ymd()
-        if (e.get('side') or '').upper()=='SWAP':
-            legs=e.get('legs') or []
-            for l in legs:
-                entry={'wallet': self.wallet,'time': e.get('time'),
-                       'side': (l.get('side') or '').upper(),'asset': (l.get('asset') or '?').upper(),
-                       'qty': l.get('qty'),'price_usd': l.get('price_usd'),'usd': l.get('usd'),'realized_usd':'0'}
-                append_ledger(day, entry)
-                try: mark_trade(entry['asset'], entry['side'])
-                except Exception: pass
-            parts=[f"{(l.get('side') or '').upper()} {(l.get('asset') or '?').upper()} {l.get('qty')}" for l in legs]
-            send_telegram_message('🔁 Swap: ' + ' | '.join(parts))
+
+    def _record_alert(self, entry: Dict[str, object]):
+        day = ymd()
+        side = (entry.get("side") or "").upper()
+        if side == "SWAP":
+            legs = entry.get("legs") or []
+            for leg in legs:
+                normalized = {
+                    "wallet": self.wallet,
+                    "time": entry.get("time"),
+                    "side": (leg.get("side") or "").upper(),
+                    "asset": (leg.get("asset") or "?").upper(),
+                    "qty": leg.get("qty"),
+                    "price_usd": leg.get("price_usd"),
+                    "usd": leg.get("usd"),
+                    "fee_usd": leg.get("fee_usd"),
+                }
+                append_ledger(day, normalized)
+                try:
+                    mark_trade(normalized["asset"], normalized["side"])
+                except Exception:
+                    logging.debug("mark_trade failed", exc_info=True)
+            parts = [
+                f"{(leg.get('side') or '').upper()} {(leg.get('asset') or '?').upper()} {leg.get('qty')}"
+                for leg in legs
+            ]
+            if parts:
+                send_telegram_message("🔁 Swap: " + " | ".join(parts))
         else:
-            entry={'wallet': self.wallet,'time': e.get('time'),
-                   'side': (e.get('side') or 'IN').upper(),'asset': (e.get('asset') or '?').upper(),
-                   'qty': e.get('qty'),'price_usd': e.get('price_usd'),'usd': e.get('usd'),'realized_usd':'0'}
-            append_ledger(day, entry)
-            try: mark_trade(entry['asset'], entry['side'])
-            except Exception: pass
-            send_telegram_message(f"{('➕' if entry['side']=='IN' else '➖')} {entry['side']} {entry['asset']} {entry['qty']}")
-    def poll_once(self):
-        raw=self.fetch_fn(self.wallet) or []
-        fresh=self._dedup(raw)
-        now=time.time()
-        for e in fresh:
-            if now - self._last < self.cooldown: continue
+            normalized = {
+                "wallet": self.wallet,
+                "time": entry.get("time"),
+                "side": (entry.get("side") or "IN").upper(),
+                "asset": (entry.get("asset") or "?").upper(),
+                "qty": entry.get("qty"),
+                "price_usd": entry.get("price_usd"),
+                "usd": entry.get("usd"),
+                "fee_usd": entry.get("fee_usd"),
+            }
+            append_ledger(day, normalized)
+            try:
+                mark_trade(normalized["asset"], normalized["side"])
+            except Exception:
+                logging.debug("mark_trade failed", exc_info=True)
+            emoji = "➕" if normalized["side"] == "IN" else "➖"
+            send_telegram_message(
+                f"{emoji} {normalized['side']} {normalized['asset']} {normalized.get('qty')}"
+            )
+
+    def poll_once(self) -> int:
+        try:
+            raw = self.fetch_fn(self.wallet) or []
+            note_wallet_poll(True)
+        except Exception as exc:  # pragma: no cover - network failures
+            logging.debug("wallet fetch failed: %s", exc)
+            note_wallet_poll(False, str(exc))
+            return 0
+
+        fresh = self._dedup(raw)
+        appended = 0
+        now = time.time()
+        for entry in fresh:
+            if now - self._last < self.cooldown:
+                continue
             self._last = now
-            self._record_alert(e)
+            self._record_alert(entry)
+            appended += 1
+
+        if appended:
+            try:
+                update_cost_basis()
+                note_cost_basis_update()
+            except Exception:
+                logging.debug("cost basis update failed", exc_info=True)
         return len(fresh)
+
+
 def make_wallet_monitor(provider=None):
-    import os
-    wallet=os.getenv('WALLET_ADDRESS','')
-    if not provider: provider=lambda _addr: []
-    cd=max(3, int(os.getenv('WALLET_ALERTS_COOLDOWN','5') or 5))
-    return WalletMonitor(wallet, provider, cd)
+    wallet = os.getenv("WALLET_ADDRESS", "")
+    if not provider:
+        provider = lambda _addr: []
+    cooldown = max(3, int(os.getenv("WALLET_ALERTS_COOLDOWN", "5") or 5))
+    return WalletMonitor(wallet, provider, cooldown)

--- a/main.py
+++ b/main.py
@@ -1,28 +1,37 @@
-import os, sys, time, logging, signal, requests, threading
-from dotenv import load_dotenv
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+from typing import Optional
+
 import schedule
-from reports.scheduler import run_pending
-from reports.day_report import build_day_report_text
-from telegram.api import send_telegram
-try:
-    from telegram.api import telegram_long_poll_loop  # new canonical name
-except ImportError:  # pragma: no cover - fallback when legacy bundle lacks the helper
-    telegram_long_poll_loop = None
-from telegram.dispatcher import dispatch
+from dotenv import load_dotenv
+
+from core.guards import set_holdings
+from core.holdings import get_wallet_snapshot
+from core.providers.cronos import fetch_wallet_txs
+from core.runtime_state import note_tick, update_snapshot
 from core.watch import make_from_env
 from core.wallet_monitor import make_wallet_monitor
-from core.providers.cronos import fetch_wallet_txs
+from reports.day_report import build_day_report_text
+from reports.weekly import build_weekly_report_text
+from reports.scheduler import run_pending
+from telegram.api import send_telegram, send_telegram_messages, telegram_long_poll_loop
+from telegram.dispatcher import dispatch
+
 try:
     from core.signals.server import start_signals_server_if_enabled
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     def start_signals_server_if_enabled():
         logging.warning("signals server disabled: Flask missing")
-from core.holdings import get_wallet_snapshot
-from core.guards import set_holdings
 
-_shutdown=False
-_updates_offset=None
-_last_error_ts=float("-inf")
+
+_shutdown = False
+_last_error_ts = float("-inf")
+_last_intraday_signature: Optional[tuple] = None
+_wallet_address: Optional[str] = None
 
 
 def _env_str(name: str, default: str = "") -> str:
@@ -43,61 +52,113 @@ def _env_float(name: str, default: float) -> float:
         logging.debug("invalid float env %s=%r", name, raw)
         return default
 
-def _setup_logging():
-    level=os.getenv("LOG_LEVEL","INFO").upper()
-    logging.basicConfig(level=getattr(logging, level, logging.INFO),
-                        format="%(asctime)s %(levelname)s %(message)s")
 
-def _handle(sig, frm):
-    global _shutdown; _shutdown=True
-
-def _legacy_telegram_long_poll_loop(handler):
-    global _updates_offset
-    token = _env_str("TELEGRAM_BOT_TOKEN")
-    if not token:
-        return
-    url = f"https://api.telegram.org/bot{token}/getUpdates"
-    params = {"timeout": 10}
-    while not _shutdown:
-        try:
-            if _updates_offset is not None:
-                params["offset"] = _updates_offset
-            r = requests.get(url, params=params, timeout=15)
-            resp = r.json() if r.headers.get("content-type", "").startswith("application/json") else {"ok": False}
-            if not resp.get("ok", True):
-                continue
-            for upd in resp.get("result", []):
-                _updates_offset = max(_updates_offset or 0, upd.get("update_id", 0) + 1)
-                msg = upd.get("message") or upd.get("edited_message") or {}
-                if not msg:
-                    continue
-                chat_id = (msg.get("chat") or {}).get("id")
-                text = msg.get("text")
-                if not text:
-                    continue
-                reply = handler(text, chat_id)
-                if reply:
-                    send_telegram(reply)
-        except Exception as e:
-            logging.debug("telegram poll failed: %s", e)
-        time.sleep(1)
+def _setup_logging() -> None:
+    level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=getattr(logging, level, logging.INFO),
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
 
 
-if telegram_long_poll_loop is None:
-    telegram_long_poll_loop = _legacy_telegram_long_poll_loop
+def _handle_shutdown(sig, frm):
+    global _shutdown
+    _shutdown = True
+
+
+def _snapshot_signature(snapshot: dict) -> tuple:
+    items = []
+    for symbol, payload in sorted(snapshot.items()):
+        qty = payload.get("qty") or payload.get("amount") or "0"
+        usd = payload.get("usd") or payload.get("value_usd") or "0"
+        items.append((symbol, str(qty), str(usd)))
+    return tuple(items)
+
 
 def _send_daily_report() -> None:
     try:
-        report = build_day_report_text(False)
+        snapshot = get_wallet_snapshot(_wallet_address)
+        update_snapshot(snapshot, time.time())
+        report = build_day_report_text(
+            intraday=False,
+            wallet=_wallet_address,
+            snapshot=snapshot,
+        )
     except Exception as exc:
         logging.exception("daily report generation failed: %s", exc)
         send_telegram("⚠️ Failed to generate daily report.", dedupe=False)
         return
-    send_telegram("📒 Daily Report\n" + report, dedupe=False)
+    send_telegram_messages([report])
+
+
+def _send_weekly_report(days: int = 7) -> None:
+    try:
+        report = build_weekly_report_text(days=days, wallet=_wallet_address)
+    except Exception as exc:
+        logging.exception("weekly report generation failed: %s", exc)
+        send_telegram("⚠️ Failed to generate weekly report.", dedupe=False)
+        return
+    send_telegram_messages([report])
 
 
 def _send_health_ping() -> None:
     send_telegram("✅ alive", dedupe=False)
+
+
+def _send_intraday_update() -> None:
+    global _last_intraday_signature
+    try:
+        snapshot = get_wallet_snapshot(_wallet_address) or {}
+        update_snapshot(snapshot, time.time())
+        signature = _snapshot_signature(snapshot)
+    except Exception as exc:
+        logging.exception("intraday snapshot failed: %s", exc)
+        send_telegram("⚠️ Failed to refresh snapshot.", dedupe=False)
+        return
+
+    if signature and signature == _last_intraday_signature:
+        send_telegram("⌛ cooldown")
+        return
+
+    _last_intraday_signature = signature
+    total_usd = 0.0
+    top_symbol = None
+    top_value = 0.0
+    for symbol, payload in snapshot.items():
+        try:
+            usd = float(payload.get("usd") or payload.get("value_usd") or 0.0)
+        except (TypeError, ValueError):
+            usd = 0.0
+        total_usd += usd
+        if usd > top_value:
+            top_symbol = symbol
+            top_value = usd
+
+    lines = ["🕒 Intraday Update"]
+    lines.append(f"Assets: {len(snapshot)} | Total ≈ ${total_usd:,.2f}")
+    if top_symbol:
+        lines.append(f"Top: {top_symbol.upper()} ≈ ${top_value:,.2f}")
+    send_telegram_messages(["\n".join(lines)])
+
+
+def _schedule_weekly_job(dow: str, at_time: str) -> None:
+    mapper = {
+        "MON": schedule.every().monday,
+        "TUE": schedule.every().tuesday,
+        "WED": schedule.every().wednesday,
+        "THU": schedule.every().thursday,
+        "FRI": schedule.every().friday,
+        "SAT": schedule.every().saturday,
+        "SUN": schedule.every().sunday,
+    }
+    job = mapper.get(dow.upper()) if dow else None
+    if not job:
+        logging.warning("invalid WEEKLY_DOW %s", dow)
+        return
+    try:
+        job.at(at_time).do(_send_weekly_report)
+    except schedule.ScheduleValueError as exc:
+        logging.warning("weekly schedule error: %s", exc)
 
 
 def _start_telegram_thread() -> None:
@@ -107,10 +168,15 @@ def _start_telegram_thread() -> None:
     tg_thread.start()
 
 
-def main()->int:
-    global _last_error_ts
-    load_dotenv(); _setup_logging()
+def main() -> int:
+    global _wallet_address
+    load_dotenv()
+    _setup_logging()
+
     send_telegram("✅ Cronos DeFi Sentinel started and is online.")
+
+    _wallet_address = _env_str("WALLET_ADDRESS", "")
+
     eod_time = _env_str("EOD_TIME", "23:59")
     try:
         schedule.every().day.at(eod_time).do(_send_daily_report)
@@ -118,6 +184,11 @@ def main()->int:
         logging.warning("invalid EOD_TIME %s: %s", eod_time, exc)
     else:
         logging.info("daily report scheduled at %s", eod_time)
+
+    weekly_dow = _env_str("WEEKLY_DOW", "SUN")
+    weekly_time = _env_str("WEEKLY_TIME", "18:00")
+    _schedule_weekly_job(weekly_dow, weekly_time)
+
     health_min = _env_float("HEALTH_MIN", 30.0)
     if health_min > 0:
         interval = max(1, int(health_min))
@@ -129,38 +200,63 @@ def main()->int:
             logging.info("health ping scheduled every %s minute(s)", interval)
     else:
         logging.info("health ping disabled")
-    watcher=make_from_env()
-    wallet_mon=make_wallet_monitor(provider=fetch_wallet_txs)
-    try: start_signals_server_if_enabled()
-    except Exception as e: logging.warning("signals server error: %s", e)
-    signal.signal(signal.SIGTERM, _handle); signal.signal(signal.SIGINT, _handle)
-    holdings_refresh = int(os.getenv("HOLDINGS_REFRESH_SEC","60") or 60); last_hold=0.0
-    wallet=os.getenv("WALLET_ADDRESS","")
-    poll=int(os.getenv("WALLET_POLL","15") or 15)
+
+    intraday_hours = _env_float("INTRADAY_HOURS", 1.0)
+    if intraday_hours > 0:
+        try:
+            schedule.every(max(1, int(intraday_hours))).hours.do(_send_intraday_update)
+        except schedule.ScheduleValueError as exc:
+            logging.warning("intraday schedule error: %s", exc)
+    else:
+        logging.info("intraday updates disabled")
+
+    watcher = make_from_env()
+    wallet_mon = make_wallet_monitor(provider=fetch_wallet_txs)
+
+    try:
+        start_signals_server_if_enabled()
+    except Exception as exc:
+        logging.warning("signals server error: %s", exc)
+
+    signal.signal(signal.SIGTERM, _handle_shutdown)
+    signal.signal(signal.SIGINT, _handle_shutdown)
+
+    holdings_refresh = int(os.getenv("HOLDINGS_REFRESH_SEC", "60") or 60)
+    last_hold = 0.0
+
     _start_telegram_thread()
+
     while not _shutdown:
-        t0=time.time()
+        t0 = time.time()
         try:
             watcher.poll_once()
             wallet_mon.poll_once()
+            note_tick()
             run_pending()
-            if time.time()-last_hold >= holdings_refresh:
-                snap=get_wallet_snapshot(wallet) or {}
-                set_holdings(set(snap.keys()))
-                last_hold=time.time()
-        except Exception as e:
-            logging.exception("loop error: %s", e)
+            if time.time() - last_hold >= holdings_refresh:
+                snapshot = get_wallet_snapshot(_wallet_address) or {}
+                update_snapshot(snapshot, time.time())
+                set_holdings(set(snapshot.keys()))
+                last_hold = time.time()
+        except Exception as exc:
+            logging.exception("loop error: %s", exc)
             now = time.monotonic()
+            global _last_error_ts
             if now - _last_error_ts >= 120:
                 send_telegram("⚠️ runtime error (throttled)", dedupe=False)
                 _last_error_ts = now
-        time.sleep(max(0.5, poll - (time.time()-t0)))
+        sleep_for = max(0.5, _env_float("WALLET_POLL", 15.0) - (time.time() - t0))
+        time.sleep(sleep_for)
     return 0
 
-if __name__=="__main__":
-    try: sys.exit(main())
-    except Exception as e:
-        logging.exception("fatal: %s", e)
-        try: send_telegram(f"💥 Fatal error: {e}")
-        except Exception: pass
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        logging.exception("fatal: %s", exc)
+        try:
+            send_telegram(f"💥 Fatal error: {exc}")
+        except Exception:
+            pass
         sys.exit(1)

--- a/reports/aggregates.py
+++ b/reports/aggregates.py
@@ -1,23 +1,118 @@
-from decimal import Decimal
-def _D(x): return Decimal(str(x or 0))
-def aggregate_per_asset(entries, wallet=None):
-    acc={}
-    for e in entries:
-        if wallet and (e.get("wallet") or "").lower()!=wallet.lower(): continue
-        a=(e.get("asset") or "?").upper()
-        acc.setdefault(a, {"in_qty":_D(0),"out_qty":_D(0),"in_usd":_D(0),"out_usd":_D(0),"realized_usd":_D(0)})
-        side=(e.get("side") or "").upper(); qty=_D(e.get("qty")); usd=_D(e.get("usd"))
-        if side=="IN": acc[a]["in_qty"]+=qty; acc[a]["in_usd"]+=usd
-        elif side=="OUT": acc[a]["out_qty"]+=qty; acc[a]["out_usd"]+=usd
-        acc[a]["realized_usd"]+=_D(e.get("realized_usd"))
-    rows=[]
-    for a,v in acc.items():
-        netq=v["in_qty"]-v["out_qty"]; netu=v["in_usd"]-v["out_usd"]
-        rows.append({"asset":a, **{k:str(vv) for k,vv in v.items()}, "net_qty":str(netq), "net_usd":str(netu)})
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _normalize_wallet(value: Optional[str]) -> str:
+    return (value or "").strip().lower()
+
+
+def aggregate_per_asset(
+    entries: Iterable[Dict[str, Any]] | None,
+    wallet: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Aggregate buy/sell ledger entries per asset.
+
+    The function keeps Decimal values so downstream formatters/tests can
+    perform precise arithmetic without string parsing.
+    """
+
+    normalized_wallet = _normalize_wallet(wallet)
+    acc: Dict[str, Dict[str, Decimal]] = defaultdict(
+        lambda: {
+            "in_qty": Decimal("0"),
+            "out_qty": Decimal("0"),
+            "in_usd": Decimal("0"),
+            "out_usd": Decimal("0"),
+            "realized_usd": Decimal("0"),
+            "tx_count": Decimal("0"),
+        }
+    )
+
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+
+        if normalized_wallet and _normalize_wallet(entry.get("wallet")) not in {
+            "",
+            normalized_wallet,
+        }:
+            continue
+
+        asset = str(entry.get("asset") or "?").upper()
+        if not asset:
+            asset = "?"
+
+        side = str(entry.get("side") or "").upper()
+        qty = _to_decimal(entry.get("qty"))
+        usd = _to_decimal(entry.get("usd"))
+        realized = _to_decimal(entry.get("realized_usd"))
+
+        bucket = acc[asset]
+        if side == "IN":
+            bucket["in_qty"] += qty
+            bucket["in_usd"] += usd
+            bucket["tx_count"] += Decimal(1)
+        elif side == "OUT":
+            bucket["out_qty"] += qty
+            bucket["out_usd"] += usd
+            bucket["tx_count"] += Decimal(1)
+        elif side == "SWAP":
+            bucket["tx_count"] += Decimal(1)
+        else:
+            # ignore unsupported side but still count to highlight activity
+            bucket["tx_count"] += Decimal(1)
+
+        bucket["realized_usd"] += realized
+
+    rows: List[Dict[str, Any]] = []
+    for asset, values in acc.items():
+        in_qty = values["in_qty"]
+        out_qty = values["out_qty"]
+        in_usd = values["in_usd"]
+        out_usd = values["out_usd"]
+        realized_usd = values["realized_usd"]
+        tx_count = int(values["tx_count"])
+        rows.append(
+            {
+                "asset": asset,
+                "in_qty": in_qty,
+                "out_qty": out_qty,
+                "net_qty": in_qty - out_qty,
+                "in_usd": in_usd,
+                "out_usd": out_usd,
+                "net_usd": in_usd - out_usd,
+                "realized_usd": realized_usd,
+                "tx_count": tx_count,
+            }
+        )
+
+    rows.sort(key=lambda row: (row["net_usd"], row["asset"]), reverse=True)
     return rows
-def totals(rows):
-    from decimal import Decimal
-    t={k:Decimal("0") for k in ["in_qty","out_qty","in_usd","out_usd","net_qty","net_usd","realized_usd"]}
-    for r in rows:
-        for k in t: t[k]+=Decimal(str(r.get(k) or 0))
-    return {k:str(v) for k,v in t.items()}
+
+
+def totals(rows: Iterable[Dict[str, Any]]) -> Dict[str, Decimal]:
+    total = {
+        "in_qty": Decimal("0"),
+        "out_qty": Decimal("0"),
+        "net_qty": Decimal("0"),
+        "in_usd": Decimal("0"),
+        "out_usd": Decimal("0"),
+        "net_usd": Decimal("0"),
+        "realized_usd": Decimal("0"),
+    }
+    for row in rows or []:
+        for key in total:
+            total[key] += _to_decimal(row.get(key))
+    return total

--- a/reports/ledger.py
+++ b/reports/ledger.py
@@ -1,16 +1,227 @@
-import os, json
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
-BASE=Path("./.ledger"); BASE.mkdir(exist_ok=True, parents=True)
-def _p(day): return BASE/f"{day}.json"
-def append_ledger(day, entry):
-    p=_p(day); data=[]
-    if p.exists():
-        try: data=json.loads(p.read_text(encoding="utf-8"))
-        except Exception: data=[]
-    data.append(entry)
-    p.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-def read_ledger(day):
-    p=_p(day)
-    if not p.exists(): return []
-    try: return json.loads(p.read_text(encoding="utf-8"))
-    except Exception: return []
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+
+from core.tz import now_gr, ymd
+
+LEDGER_DIR = Path(os.getenv("LEDGER_DIR", "./.ledger")).expanduser()
+LEDGER_DIR.mkdir(parents=True, exist_ok=True)
+COST_BASIS_FILE = LEDGER_DIR / "cost_basis.json"
+
+_DECIMAL_KEYS = ("qty", "price_usd", "usd", "fee_usd", "realized_usd")
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _serialize_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    for key, value in entry.items():
+        if key in _DECIMAL_KEYS and value is not None:
+            payload[key] = str(_to_decimal(value))
+        else:
+            payload[key] = value
+    return payload
+
+
+def _deserialize_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    for key, value in entry.items():
+        if key in _DECIMAL_KEYS:
+            data[key] = _to_decimal(value)
+        else:
+            data[key] = value
+    if "realized_usd" not in data:
+        data["realized_usd"] = Decimal("0")
+    return data
+
+
+def _day_from_entry(entry: Dict[str, Any]) -> Optional[str]:
+    ts = entry.get("time") or entry.get("timestamp")
+    if ts is None:
+        return None
+    try:
+        ts_int = int(float(ts))
+    except (TypeError, ValueError):
+        return None
+    dt = datetime.fromtimestamp(ts_int, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%d")
+
+
+def data_file_for_day(day: str) -> Path:
+    return LEDGER_DIR / f"{day}.json"
+
+
+def data_file_for_today() -> Path:
+    return data_file_for_day(ymd())
+
+
+def _read_day_raw(day: str) -> List[Dict[str, Any]]:
+    path = data_file_for_day(day)
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+
+def _write_day(day: str, entries: Iterable[Dict[str, Any]]) -> None:
+    payload = [_serialize_entry(entry) for entry in entries]
+    data_file_for_day(day).write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _is_valid_day(name: str) -> bool:
+    try:
+        datetime.strptime(name, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return True
+
+
+def list_days() -> List[str]:
+    return sorted(
+        [
+            path.stem
+            for path in LEDGER_DIR.glob("*.json")
+            if path.is_file() and _is_valid_day(path.stem)
+        ]
+    )
+
+
+def read_ledger(day: str) -> List[Dict[str, Any]]:
+    raw_entries = _read_day_raw(day)
+    entries = [_deserialize_entry(entry) for entry in raw_entries]
+    entries.sort(key=lambda entry: entry.get("time") or 0)
+    return entries
+
+
+def iter_all_entries() -> Iterator[Dict[str, Any]]:
+    for day in list_days():
+        for entry in read_ledger(day):
+            yield entry
+
+
+def append_ledger(day_or_entry: Any, entry: Optional[Dict[str, Any]] = None) -> None:
+    if entry is None:
+        if not isinstance(day_or_entry, dict):
+            raise ValueError("append_ledger(entry) requires a dict entry")
+        entry = dict(day_or_entry)
+        day = entry.pop("day", None) or _day_from_entry(entry) or ymd()
+    else:
+        day = str(day_or_entry)
+        entry = dict(entry)
+
+    normalized = _deserialize_entry(entry)
+    normalized.setdefault("wallet", entry.get("wallet"))
+    if normalized.get("realized_usd") is None:
+        normalized["realized_usd"] = Decimal("0")
+
+    day_entries = read_ledger(day)
+    day_entries.append(normalized)
+    day_entries.sort(key=lambda item: item.get("time") or 0)
+    _write_day(day, day_entries)
+
+
+def _clone_basis(basis: Dict[str, List[Dict[str, Decimal]]]) -> Dict[str, List[Dict[str, Decimal]]]:
+    cloned: Dict[str, List[Dict[str, Decimal]]] = {}
+    for asset, lots in basis.items():
+        cloned[asset] = [
+            {"qty": Decimal(lot["qty"]), "usd": Decimal(lot["usd"])} for lot in lots
+        ]
+    return cloned
+
+
+def _consume_lots(lots: List[Dict[str, Decimal]], qty: Decimal) -> Decimal:
+    remaining = qty
+    cost = Decimal("0")
+    while remaining > 0 and lots:
+        lot = lots[0]
+        lot_qty = lot["qty"]
+        lot_usd = lot["usd"]
+        if lot_qty <= 0:
+            lots.pop(0)
+            continue
+        take = lot_qty if lot_qty <= remaining else remaining
+        proportion = take / lot_qty if lot_qty else Decimal("0")
+        cost += lot_usd * proportion
+        lot["qty"] = lot_qty - take
+        lot["usd"] = lot_usd - (lot_usd * proportion)
+        remaining -= take
+        if lot["qty"] <= Decimal("0"):
+            lots.pop(0)
+    return cost
+
+
+def replay_cost_basis_over_entries(
+    entries: Iterable[Dict[str, Any]],
+    basis: Optional[Dict[str, List[Dict[str, Decimal]]]] = None,
+) -> Tuple[Dict[str, List[Dict[str, Decimal]]], Dict[str, Decimal], List[Dict[str, Any]]]:
+    basis_state = _clone_basis(basis or {})
+    realized_totals: Dict[str, Decimal] = {}
+    annotated_entries: List[Dict[str, Any]] = []
+
+    for raw in entries or []:
+        entry = _deserialize_entry(dict(raw))
+        asset = str(entry.get("asset") or "?").upper()
+        side = str(entry.get("side") or "").upper()
+        qty = _to_decimal(entry.get("qty"))
+        usd = _to_decimal(entry.get("usd"))
+        fee = _to_decimal(entry.get("fee_usd"))
+
+        lots = basis_state.setdefault(asset, [])
+        realized = Decimal("0")
+
+        if side == "IN" and qty > 0:
+            lots.append({"qty": qty, "usd": usd + fee})
+        elif side == "OUT" and qty > 0:
+            proceeds = usd - fee
+            cost = _consume_lots(lots, qty)
+            realized = proceeds - cost
+        entry["realized_usd"] = realized
+        realized_totals[asset] = realized_totals.get(asset, Decimal("0")) + realized
+        annotated_entries.append(entry)
+
+    return basis_state, realized_totals, annotated_entries
+
+
+def update_cost_basis() -> None:
+    basis: Dict[str, List[Dict[str, Decimal]]] = {}
+    for day in list_days():
+        entries = read_ledger(day)
+        basis, _, annotated = replay_cost_basis_over_entries(entries, basis)
+        _write_day(day, annotated)
+
+    payload = {
+        asset: [{"qty": str(lot["qty"]), "usd": str(lot["usd"]) } for lot in lots]
+        for asset, lots in basis.items()
+    }
+    COST_BASIS_FILE.write_text(
+        json.dumps({"updated_at": now_gr().isoformat(), "basis": payload}, indent=2),
+        encoding="utf-8",
+    )
+
+
+__all__ = [
+    "append_ledger",
+    "data_file_for_today",
+    "iter_all_entries",
+    "list_days",
+    "read_ledger",
+    "replay_cost_basis_over_entries",
+    "update_cost_basis",
+]

--- a/telegram/api.py
+++ b/telegram/api.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import requests
 
@@ -25,6 +27,7 @@ def _resolve_dedup_window(raw: str) -> float:
 DEDUP_WINDOW_SEC = _resolve_dedup_window(os.getenv("TG_DEDUP_WINDOW_SEC", "").strip())
 _last_message_text: Optional[str] = None
 _last_message_ts: Optional[float] = None
+_MAX_MESSAGE_LEN = 4096
 
 
 def _post(payload: Dict[str, Any]) -> Tuple[bool, int, Any]:
@@ -37,14 +40,32 @@ def _post(payload: Dict[str, Any]) -> Tuple[bool, int, Any]:
     return response.ok, response.status_code, response.text
 
 
-def send_telegram(
-    text: str, parse_mode: Optional[str] = None, dedupe: bool = True
-) -> Tuple[bool, int, Any]:
-    """Send a Telegram message.
+def _chunk_text(text: str, limit: int = _MAX_MESSAGE_LEN) -> List[str]:
+    if text is None:
+        return []
+    text = str(text)
+    if len(text) <= limit:
+        return [text]
+    chunks: List[str] = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= limit:
+            chunks.append(remaining)
+            break
+        split_at = remaining.rfind("\n", 0, limit)
+        if split_at == -1 or split_at < limit // 2:
+            split_at = limit
+        chunks.append(remaining[:split_at].rstrip())
+        remaining = remaining[split_at:].lstrip("\n")
+    return chunks
 
-    Defaults to plain text. When MarkdownV2 is explicitly requested, escape the
-    payload before sending it to Telegram.
-    """
+
+def send_telegram(
+    text: str,
+    parse_mode: Optional[str] = None,
+    dedupe: bool = True,
+) -> Tuple[bool, int, Any]:
+    """Send a Telegram message."""
     global _last_message_text, _last_message_ts
 
     mode = parse_mode or None
@@ -76,6 +97,54 @@ def send_telegram(
     return ok, status_code, response
 
 
+def send_telegram_messages(messages: Iterable[str]) -> List[Tuple[bool, int, Any]]:
+    results: List[Tuple[bool, int, Any]] = []
+    for message in messages or []:
+        for chunk in _chunk_text(message):
+            results.append(send_telegram(chunk))
+    return results
+
+
 def send_telegram_message(text: str) -> None:
     """Backward compatible helper used by legacy modules."""
     send_telegram(text)
+
+
+def telegram_long_poll_loop(dispatcher) -> None:
+    if not TOKEN:
+        logging.info("telegram token missing; skipping long poll loop")
+        return
+
+    url = f"https://api.telegram.org/bot{TOKEN}/getUpdates"
+    params: Dict[str, Any] = {"timeout": 20}
+    offset: Optional[int] = None
+
+    while True:
+        try:
+            if offset is not None:
+                params["offset"] = offset
+            response = requests.get(url, params=params, timeout=25)
+            data = response.json() if response.headers.get("content-type", "").startswith("application/json") else {}
+            updates = data.get("result", []) if data.get("ok", True) else []
+        except Exception as exc:  # pragma: no cover - network failures
+            logging.debug("telegram poll failed: %s", exc)
+            time.sleep(2)
+            continue
+
+        for update in updates:
+            try:
+                offset = max(offset or 0, int(update.get("update_id", 0)) + 1)
+            except Exception:
+                continue
+            message = update.get("message") or update.get("edited_message") or {}
+            text = message.get("text")
+            chat = message.get("chat") or {}
+            chat_id = chat.get("id")
+            if not text:
+                continue
+            replies = dispatcher(text, chat_id)
+            if not replies:
+                continue
+            send_telegram_messages(replies)
+
+        time.sleep(0.5)

--- a/telegram/commands.py
+++ b/telegram/commands.py
@@ -1,16 +1,289 @@
-from core.holdings import get_wallet_snapshot
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from core.runtime_state import get_snapshot, get_state
+from core.tz import ymd
+from reports.aggregates import aggregate_per_asset, totals
 from reports.day_report import build_day_report_text
+from reports.ledger import iter_all_entries, read_ledger
 from reports.weekly import build_weekly_report_text
 
-def handle_holdings()->str:
-    snap=get_wallet_snapshot()
-    if not snap: return "No holdings available."
-    lines=["Holdings snapshot:",""]
-    for a,info in snap.items():
-        qty=info.get("qty","?"); px=info.get("price_usd"); usd=info.get("usd")
-        lines.append(f"  – {a}: {qty}" + (f" @ ${px} = ${usd}" if px is not None and usd is not None else ""))
+
+def _fmt_decimal(value: Decimal) -> str:
+    value = Decimal(value)
+    if value == 0:
+        return "0"
+    if abs(value) >= 1:
+        return f"{value:,.2f}"
+    return f"{value:.6f}"
+
+
+def _fmt_pct(value: Decimal) -> str:
+    try:
+        return f"{Decimal(value):.2f}%"
+    except Exception:
+        return "0%"
+
+
+def _format_age(ts: Optional[float]) -> str:
+    if not ts:
+        return "never"
+    delta = max(0.0, time.time() - ts)
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    return f"{int(delta // 86400)}d ago"
+
+
+def handle_diag() -> str:
+    state = get_state()
+    wallet = os.getenv("WALLET_ADDRESS", "")
+
+    lines = ["Diagnostics:"]
+    rpc_ok_ts = state.get("last_rpc_ok_ts")
+    rpc_error = state.get("last_rpc_error")
+    if rpc_ok_ts:
+        rpc_line = f"RPC reachable: yes ({_format_age(rpc_ok_ts)})"
+    elif rpc_error:
+        rpc_line = f"RPC reachable: no (last error: {rpc_error})"
+    else:
+        rpc_line = "RPC reachable: unknown"
+    lines.append(rpc_line)
+
+    lines.append(f"Wallet configured: {'yes' if wallet else 'no'}")
+    lines.append(f"Last tick: {_format_age(state.get('last_tick_ts'))}")
+    lines.append(f"Last wallet poll: {_format_age(state.get('last_wallet_poll_ts'))}")
+
+    queues = state.get("queue_sizes") or {}
+    if queues:
+        for name, size in sorted(queues.items()):
+            lines.append(f"Queue {name}: {size}")
+    else:
+        lines.append("Queue sizes: n/a")
+
+    cost_basis_ts = state.get("last_cost_basis_update")
+    if cost_basis_ts:
+        lines.append(f"Cost basis updated: {_format_age(cost_basis_ts)}")
+
     return "\n".join(lines)
 
-def handle_show()->str: return build_day_report_text(True)
-def handle_showdaily()->str: return build_day_report_text(False)
-def handle_weekly(days:int=7)->str: return build_weekly_report_text(days=days)
+
+def handle_status() -> str:
+    state = get_state()
+    snapshot = state.get("snapshot") or {}
+    total = Decimal(state.get("snapshot_total_usd") or 0)
+    lines = ["Status:"]
+    lines.append(f"Assets tracked: {len(snapshot)}")
+    lines.append(f"Estimated total: ${_fmt_decimal(total)}")
+    lines.append(f"Snapshot age: {_format_age(state.get('snapshot_ts'))}")
+    lines.append(f"Last wallet poll: {_format_age(state.get('last_wallet_poll_ts'))}")
+    return "\n".join(lines)
+
+
+def handle_holdings(limit: int = 20) -> str:
+    snapshot = get_snapshot()
+    if not snapshot:
+        return "No holdings snapshot available."
+
+    items: List[tuple[str, Decimal, Decimal]] = []
+    for symbol, data in snapshot.items():
+        qty = Decimal(str(data.get("qty") or data.get("amount") or "0"))
+        usd = Decimal(str(data.get("usd") or data.get("value_usd") or "0"))
+        items.append((symbol.upper(), qty, usd))
+
+    items.sort(key=lambda item: item[2], reverse=True)
+
+    lines = ["Holdings (top {limit}):".format(limit=limit)]
+    for symbol, qty, usd in items[:limit]:
+        lines.append(f" - {symbol:<6} {qty:>12,.4f} ≈ ${usd:,.2f}")
+
+    if len(items) > limit:
+        remaining = sum(usd for _, _, usd in items[limit:])
+        lines.append(f" ... {len(items) - limit} more positions totaling ≈ ${remaining:,.2f}")
+
+    total_usd = sum(usd for _, _, usd in items)
+    lines.append("")
+    lines.append(f"Total ≈ ${total_usd:,.2f}")
+    return "\n".join(lines)
+
+
+def handle_totals() -> str:
+    entries = list(iter_all_entries())
+    rows = aggregate_per_asset(entries)
+    if not rows:
+        return "Ledger is empty."
+
+    totals_row = totals(rows)
+    base_values = [
+        max(
+            abs(row.get("net_usd", Decimal("0"))),
+            row.get("in_usd", Decimal("0")),
+            row.get("out_usd", Decimal("0")),
+        )
+        for row in rows
+    ]
+    base_total = sum(base_values)
+    if base_total <= 0:
+        base_total = sum(abs(row.get("realized_usd", Decimal("0"))) for row in rows)
+
+    rows.sort(key=lambda row: row.get("net_usd", Decimal("0")), reverse=True)
+    top = rows[:10]
+    others = rows[10:]
+
+    lines = ["Totals & Allocation:"]
+    for row in top:
+        share_base = max(
+            abs(row.get("net_usd", Decimal("0"))),
+            row.get("in_usd", Decimal("0")),
+            row.get("out_usd", Decimal("0")),
+        )
+        pct = (share_base / base_total * 100) if base_total else Decimal("0")
+        lines.append(
+            " - {asset}: NET ${net_usd} | Realized ${realized} | Share {share}".format(
+                asset=row.get("asset", "?"),
+                net_usd=_fmt_decimal(row.get("net_usd", Decimal("0"))),
+                realized=_fmt_decimal(row.get("realized_usd", Decimal("0"))),
+                share=_fmt_pct(pct),
+            )
+        )
+
+    if others:
+        others_net = sum(row.get("net_usd", Decimal("0")) for row in others)
+        others_realized = sum(row.get("realized_usd", Decimal("0")) for row in others)
+        share_base = sum(
+            max(
+                abs(row.get("net_usd", Decimal("0"))),
+                row.get("in_usd", Decimal("0")),
+                row.get("out_usd", Decimal("0")),
+            )
+            for row in others
+        )
+        pct = (share_base / base_total * 100) if base_total else Decimal("0")
+        lines.append(
+            " - Others: NET ${net_usd} | Realized ${realized} | Share {share}".format(
+                net_usd=_fmt_decimal(others_net),
+                realized=_fmt_decimal(others_realized),
+                share=_fmt_pct(pct),
+            )
+        )
+
+    lines.append("")
+    lines.append(
+        "Totals — IN ${in_usd} / OUT ${out_usd} / NET ${net_usd} / Realized ${realized}".format(
+            in_usd=_fmt_decimal(totals_row["in_usd"]),
+            out_usd=_fmt_decimal(totals_row["out_usd"]),
+            net_usd=_fmt_decimal(totals_row["net_usd"]),
+            realized=_fmt_decimal(totals_row["realized_usd"]),
+        )
+    )
+    return "\n".join(lines)
+
+
+def handle_daily() -> str:
+    snapshot = get_snapshot()
+    wallet = os.getenv("WALLET_ADDRESS", "")
+    return build_day_report_text(
+        intraday=False,
+        wallet=wallet,
+        snapshot=snapshot,
+        day=ymd(),
+    )
+
+
+def handle_weekly(days: int = 7) -> str:
+    wallet = os.getenv("WALLET_ADDRESS", "")
+    return build_weekly_report_text(days=days, wallet=wallet)
+
+
+def _entries_for_asset(symbol: str) -> List[Dict[str, object]]:
+    symbol = symbol.upper()
+    return [
+        entry
+        for entry in iter_all_entries()
+        if str(entry.get("asset") or "").upper() == symbol
+    ]
+
+
+def handle_pnl(symbol: Optional[str] = None) -> str:
+    if symbol:
+        entries = _entries_for_asset(symbol)
+        symbol = symbol.upper()
+        if not entries:
+            return f"No ledger entries for {symbol}."
+        buys = [e for e in entries if str(e.get("side")).upper() == "IN"]
+        sells = [e for e in entries if str(e.get("side")).upper() == "OUT"]
+        realized = sum(Decimal(e.get("realized_usd", 0)) for e in entries)
+        qty_net = sum(
+            Decimal(e.get("qty", 0)) * (1 if str(e.get("side")).upper() == "IN" else -1)
+            for e in entries
+        )
+        spent = sum(Decimal(e.get("usd", 0)) for e in buys)
+        received = sum(Decimal(e.get("usd", 0)) for e in sells)
+        lines = [f"PnL for {symbol}:"]
+        lines.append(f" - Buys: {len(buys)} totaling ${_fmt_decimal(spent)}")
+        lines.append(f" - Sells: {len(sells)} totaling ${_fmt_decimal(received)}")
+        lines.append(f" - Net qty: {_fmt_decimal(qty_net)}")
+        lines.append(f" - Realized PnL: ${_fmt_decimal(realized)}")
+        return "\n".join(lines)
+
+    rows = aggregate_per_asset(iter_all_entries())
+    if not rows:
+        return "Ledger is empty."
+    rows.sort(key=lambda row: abs(row.get("realized_usd", Decimal("0"))), reverse=True)
+    top = rows[:5]
+    lines = ["Top movers by realized PnL:"]
+    for row in top:
+        realized = row.get("realized_usd", Decimal("0"))
+        direction = "+" if realized >= 0 else ""
+        lines.append(
+            f" - {row.get('asset', '?')}: {direction}${_fmt_decimal(realized)} (net ${_fmt_decimal(row.get('net_usd', Decimal('0')))} )"
+        )
+    return "\n".join(lines)
+
+
+def handle_tx(symbol: Optional[str] = None, day: Optional[str] = None) -> str:
+    day = day or ymd()
+    entries = read_ledger(day)
+    if symbol:
+        symbol = symbol.upper()
+        entries = [
+            entry
+            for entry in entries
+            if str(entry.get("asset") or "").upper() == symbol
+        ]
+    if not entries:
+        target = f" for {symbol}" if symbol else ""
+        return f"No transactions on {day}{target}."
+
+    limit = 20
+    lines = [f"Transactions on {day}{(' for ' + symbol) if symbol else ''}:"]
+    for entry in entries[:limit]:
+        ts = entry.get("time")
+        if ts:
+            try:
+                dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                ts_text = dt.strftime("%H:%M:%S")
+            except Exception:
+                ts_text = str(ts)
+        else:
+            ts_text = "--"
+        lines.append(
+            " - {ts} {side} {asset} {qty} @ ${usd}".format(
+                ts=ts_text,
+                side=str(entry.get("side") or "?").upper(),
+                asset=str(entry.get("asset") or "?").upper(),
+                qty=_fmt_decimal(entry.get("qty", Decimal("0"))),
+                usd=_fmt_decimal(entry.get("usd", Decimal("0"))),
+            )
+        )
+    if len(entries) > limit:
+        lines.append(" ... more ...")
+    return "\n".join(lines)

--- a/telegram/dispatcher.py
+++ b/telegram/dispatcher.py
@@ -1,17 +1,92 @@
-from telegram.commands import handle_holdings, handle_show, handle_showdaily, handle_weekly
+from __future__ import annotations
+
 import time
-ALIASES={'/holdings':handle_holdings,'/show':handle_show,'/status':handle_show,'/report':handle_showdaily,'/showdaily':handle_showdaily,'/weekly':handle_weekly}
-_last={}; COOL=5
-def dispatch(text, chat_id=None):
-    if not text: return None
-    cmd=text.strip().split()[0].lower()
-    fn=ALIASES.get(cmd); 
-    if not fn: return None
-    now=time.time(); k=(cmd,int(chat_id) if chat_id else None)
-    if now-_last.get(k,0)<COOL: return "⌛ cooldown"
-    _last[k]=now
-    if fn is handle_weekly and len(text.split())>1:
-        try: days=max(1,min(31,int(text.split()[1])))
-        except: days=7
-        return fn(days=days)
-    return fn()
+from typing import Callable, Dict, List, Optional
+
+from telegram.commands import (
+    handle_daily,
+    handle_diag,
+    handle_holdings,
+    handle_pnl,
+    handle_status,
+    handle_totals,
+    handle_tx,
+    handle_weekly,
+)
+
+_COOLDOWN_SEC = 5
+_last_exec: Dict[tuple[str, Optional[int]], float] = {}
+
+
+def _cooldown_key(command: str, chat_id: Optional[int]) -> tuple[str, Optional[int]]:
+    return command, chat_id
+
+
+def _under_cooldown(command: str, chat_id: Optional[int]) -> bool:
+    key = _cooldown_key(command, chat_id)
+    now = time.time()
+    last = _last_exec.get(key, 0.0)
+    if now - last < _COOLDOWN_SEC:
+        return True
+    _last_exec[key] = now
+    return False
+
+
+def _parse_weekly_args(args: List[str]) -> int:
+    if not args:
+        return 7
+    try:
+        value = int(args[0])
+    except (TypeError, ValueError):
+        return 7
+    return max(1, min(31, value))
+
+
+def _parse_tx_args(args: List[str]) -> tuple[Optional[str], Optional[str]]:
+    symbol = None
+    day = None
+    for arg in args:
+        if arg and any(ch.isdigit() for ch in arg) and "-" in arg:
+            day = arg
+        elif symbol is None:
+            symbol = arg
+    return symbol, day
+
+
+def dispatch(text: str, chat_id: Optional[int] = None) -> List[str]:
+    if not text:
+        return []
+    parts = text.strip().split()
+    if not parts:
+        return []
+
+    command = parts[0].lower()
+    args = parts[1:]
+
+    handlers: Dict[str, Callable[[List[str]], List[str]]] = {
+        "/diag": lambda _args: [handle_diag()],
+        "/status": lambda _args: [handle_status()],
+        "/holdings": lambda _args: [handle_holdings()],
+        "/totals": lambda _args: [handle_totals()],
+        "/daily": lambda _args: [handle_daily()],
+        "/weekly": lambda a: [handle_weekly(_parse_weekly_args(a))],
+        "/pnl": lambda a: [handle_pnl(a[0]) if a else handle_pnl(None)],
+        "/tx": lambda a: [handle_tx(*_parse_tx_args(a))],
+    }
+
+    handler = handlers.get(command)
+    if handler is None:
+        return []
+
+    if _under_cooldown(command, chat_id):
+        return ["⌛ cooldown"]
+
+    result = handler(args)
+    if not result:
+        return []
+
+    output: List[str] = []
+    for item in result:
+        if isinstance(item, str):
+            output.append(item)
+    return output

--- a/telegram/formatters.py
+++ b/telegram/formatters.py
@@ -1,78 +1,67 @@
+from __future__ import annotations
+
 import re
 from decimal import Decimal
+from typing import Dict
 
-# --- MarkdownV2 escaping ---
+
+# --- MarkdownV2 escaping (retained for backwards compatibility) ---
 def escape_md(text: str) -> str:
     if not text:
         return ""
-    # Escape Telegram MarkdownV2 specials
-    return re.sub(r'([_*>\[\]()~`>#+\-=|{}.!])', r'\\\1', str(text))
+    return re.sub(r"([_*`\[\]()~>#+\-=|{}.!])", r"\\\\\1", str(text))
 
-# --- Holdings snapshot ---
-def _dec(x) -> Decimal:
+
+# --- Helpers ---
+def _dec(value) -> Decimal:
     try:
-        return Decimal(str(x))
+        return Decimal(str(value))
     except Exception:
         return Decimal("0")
 
-def format_holdings(snapshot: dict) -> str:
-    """
-    Pretty-format holdings snapshot for Telegram.
-    Accepts either:
-      {"SYMBOL": {"amount": ..., "price": ...}}
-    or
-      {"SYMBOL": {"qty": ..., "price_usd": ...}}
-    """
+
+def format_holdings(snapshot: Dict[str, Dict[str, object]]) -> str:
     if not snapshot:
-        return "❌ Empty snapshot"
+        return "Holdings snapshot is empty."
 
-    lines = ["\U0001F4B0 *Holdings Snapshot*", ""]
-
+    lines = ["Holdings snapshot:"]
     total_usd = Decimal("0")
-    for symbol, item in snapshot.items():
-        amount = _dec(item.get("amount", item.get("qty", 0)))
-        price  = _dec(item.get("price", item.get("price_usd", 0)))
-        value  = amount * price
+    for symbol, data in sorted(snapshot.items()):
+        qty = _dec(data.get("amount", data.get("qty", 0)))
+        price = _dec(data.get("price", data.get("price_usd", 0)))
+        value = qty * price
         total_usd += value
-        # Keep code block look for symbol, align numbers
-        line = f"`{symbol:<8}` {amount:>12,.4f} × ${price:,.6f} = ${value:,.2f}"
-        lines.append(line)
+        lines.append(
+            f" - {symbol.upper():<8} {qty:>12,.4f} × ${price:,.6f} = ${value:,.2f}"
+        )
 
     lines.append("")
-    lines.append(f"*Total:* ${total_usd:,.2f}")
+    lines.append(f"Total ≈ ${total_usd:,.2f}")
+    return "\n".join(lines)
 
-    return escape_md("\n".join(lines))
-
-# --- Per-asset totals (for tests) ---
-def _period_title(p) -> str:
-    if isinstance(p, str) and p.lower() == "today":
-        return "Today"
-    return str(p).title()
 
 def format_per_asset_totals(period: str, rows: list[dict]) -> str:
-    """
-    Formats the output of reports.aggregates.aggregate_per_asset for Telegram.
-    Includes TXs count (used in tests).
-    """
-    title = f"Totals per Asset — {_period_title(period)}"
-    out = [f"*{title}*", ""]
-
-    for r in rows or []:
-        asset = r.get("asset", "?")
-        in_qty  = _dec(r.get("in_qty"))
-        out_qty = _dec(r.get("out_qty"))
-        net_qty = _dec(r.get("net_qty"))
-        in_usd  = _dec(r.get("in_usd"))
-        out_usd = _dec(r.get("out_usd"))
-        net_usd = _dec(r.get("net_usd"))
-        txs     = int(r.get("tx_count", 0))
-
-        line = (
-            f"`{asset:<6}` "
-            f"Q: {in_qty} in / {out_qty} out → {net_qty} net | "
-            f"$: {in_usd} in / {out_usd} out → {net_usd} net | "
-            f"TXs: {txs}"
+    title = f"Totals per Asset — {str(period).title()}"
+    lines = [title]
+    for row in rows or []:
+        asset = row.get("asset", "?")
+        in_qty = _dec(row.get("in_qty"))
+        out_qty = _dec(row.get("out_qty"))
+        net_qty = _dec(row.get("net_qty"))
+        in_usd = _dec(row.get("in_usd"))
+        out_usd = _dec(row.get("out_usd"))
+        net_usd = _dec(row.get("net_usd"))
+        txs = int(row.get("tx_count", 0))
+        lines.append(
+            " - {asset:<6} Q: {in_qty} in / {out_qty} out → {net_qty} net | $: {in_usd} in / {out_usd} out → {net_usd} net | TXs: {txs}".format(
+                asset=asset,
+                in_qty=in_qty,
+                out_qty=out_qty,
+                net_qty=net_qty,
+                in_usd=in_usd,
+                out_usd=out_usd,
+                net_usd=net_usd,
+                txs=txs,
+            )
         )
-        out.append(line)
-
-    return escape_md("\n".join(out))
+    return "\n".join(lines)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import time
+from decimal import Decimal
+
+import pytest
+
+from core.runtime_state import note_tick, note_wallet_poll, update_snapshot
+from telegram import commands as cmd
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_state():
+    update_snapshot({}, time.time())
+    note_wallet_poll(True)
+    note_tick()
+    yield
+
+
+def _sample_entries():
+    return [
+        {
+            "wallet": "0xabc",
+            "asset": "ABC",
+            "side": "IN",
+            "qty": Decimal("10"),
+            "usd": Decimal("100"),
+            "realized_usd": Decimal("0"),
+            "time": int(time.time()),
+        },
+        {
+            "wallet": "0xabc",
+            "asset": "ABC",
+            "side": "OUT",
+            "qty": Decimal("4"),
+            "usd": Decimal("60"),
+            "realized_usd": Decimal("20"),
+            "time": int(time.time()),
+        },
+        {
+            "wallet": "0xabc",
+            "asset": "XYZ",
+            "side": "IN",
+            "qty": Decimal("5"),
+            "usd": Decimal("25"),
+            "realized_usd": Decimal("0"),
+            "time": int(time.time()),
+        },
+    ]
+
+
+def test_command_lengths(monkeypatch):
+    entries = _sample_entries()
+
+    monkeypatch.setattr(cmd, "iter_all_entries", lambda: iter(entries))
+    monkeypatch.setattr(cmd, "read_ledger", lambda _day: entries)
+    monkeypatch.setattr(cmd, "build_day_report_text", lambda **_kw: "daily text")
+    monkeypatch.setattr(cmd, "build_weekly_report_text", lambda **_kw: "weekly text")
+
+    update_snapshot({"ABC": {"qty": "10", "usd": "100"}}, time.time())
+    note_wallet_poll(True)
+    note_tick()
+
+    outputs = [
+        cmd.handle_diag(),
+        cmd.handle_status(),
+        cmd.handle_holdings(),
+        cmd.handle_totals(),
+        cmd.handle_daily(),
+        cmd.handle_weekly(),
+        cmd.handle_pnl("ABC"),
+        cmd.handle_pnl(None),
+        cmd.handle_tx("ABC"),
+        cmd.handle_tx(None),
+    ]
+
+    for text in outputs:
+        assert isinstance(text, str)
+        assert len(text) <= 4096

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+from decimal import Decimal
+
+
+def test_cost_basis_replay(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEDGER_DIR", str(tmp_path))
+    ledger = importlib.reload(importlib.import_module("reports.ledger"))
+
+    buy_entry = {
+        "wallet": "0xabc",
+        "time": 1700000000,
+        "side": "IN",
+        "asset": "ABC",
+        "qty": "10",
+        "usd": "100",
+    }
+    sell_entry = {
+        "wallet": "0xabc",
+        "time": 1700003600,
+        "side": "OUT",
+        "asset": "ABC",
+        "qty": "4",
+        "usd": "80",
+    }
+
+    ledger.append_ledger("2023-11-14", buy_entry)
+    ledger.append_ledger("2023-11-15", sell_entry)
+
+    ledger.update_cost_basis()
+
+    day1 = ledger.read_ledger("2023-11-14")
+    day2 = ledger.read_ledger("2023-11-15")
+
+    assert day1[0]["realized_usd"] == Decimal("0")
+    assert day2[0]["realized_usd"].quantize(Decimal("0.01")) == Decimal("40.00")
+
+    basis_file = ledger.COST_BASIS_FILE
+    assert basis_file.exists()


### PR DESCRIPTION
## Summary
- add a runtime state registry and upgrade ledger aggregation/cost-basis replay so reports can compute accurate realized PnL
- wire Telegram handlers for diag/status/holdings/totals/daily/weekly/pnl/tx plus long-poll dispatcher, intraday pings, and scheduled daily/weekly pushes
- refactor reporting formats to plain text and cover the new command surface with pytest simulations

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38ea5f65c83238e6123bb9a40cfc2