### PR TITLE
recovery/batch2: runtime recovery (no side-effects on import) + EOD scheduler + scripts hygiene

### DIFF
--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -1,43 +1,28 @@
 name: Runtime Smoke
-
 on:
-  workflow_dispatch:
-
+  workflow_dispatch: {}
 jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install deps (best-effort)
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - name: Import check (no side-effects)
         run: |
-          python -V
-          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
-          # αν δεν υπάρχει στο requirements
-          pip install requests || true
-
-      - name: Run main.py --once
-        env:
-          TZ: ${{ secrets.TZ }}
-          WALLET_ADDRESS: ${{ secrets.WALLET_ADDRESS }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          DEX_PAIRS: ${{ secrets.DEX_PAIRS }}
-          INTRADAY_HOURS: "3"
-          EOD_TIME: "23:59"
-        run: |
-          set -e
-          python main.py --once | tee runtime_output.txt
-
-      - name: Job Summary
-        run: |
-          echo "## main.py --once output" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat runtime_output.txt >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python - <<'PY'
+          import importlib, sys
+          mods = [
+            "main",
+            "core.alerts","core.config","core.guards","core.holdings","core.pricing",
+            "core.providers.cronos","core.providers.etherscan_like","core.rpc",
+            "core.runtime_state","core.tz","core.wallet_monitor","core.watch",
+            "reports.aggregates","reports.day_report","reports.ledger","reports.scheduler","reports.weekly",
+            "telegram.api","telegram.commands","telegram.dispatcher","telegram.formatters","telegram.send",
+          ]
+          for m in mods:
+              importlib.import_module(m)
+          print("✅ Import pass without side-effects")
+          PY
+      - name: Run ping
+        run: python scripts/cordex_ping.py

--- a/core/guards.py
+++ b/core/guards.py
@@ -1,41 +1,175 @@
+from __future__ import annotations
+
+import os
+import time
 from decimal import Decimal
-import os, time
-from typing import Optional, Dict, Any, Set
-GUARD_PUMP_PCT=Decimal(os.getenv('GUARD_PUMP_PCT','20'))
-GUARD_DROP_PCT=Decimal(os.getenv('GUARD_DROP_PCT','-12'))
-GUARD_TRAIL_DROP_PCT=Decimal(os.getenv('GUARD_TRAIL_DROP_PCT','-8'))
-MIN_VOLUME=Decimal(os.getenv('MIN_VOLUME_FOR_ALERT','0'))
-MIN_LIQ=Decimal(os.getenv('DISCOVER_MIN_LIQ_USD','0'))
-SPIKE=Decimal(os.getenv('SPIKE_THRESHOLD','8'))
-COOL=max(10,int(os.getenv('ALERTS_INTERVAL_MINUTES','0') or 0)*60) if os.getenv('ALERTS_INTERVAL_MINUTES') else 30
-_last={}; peaks={}; traded:Set[str]=set(); holdings:Set[str]=set()
-def mark_trade(symbol:str, side:str): traded.add(symbol.upper())
-def set_holdings(symbols:set[str]): 
-    global holdings; holdings={s.upper() for s in (symbols or set())}
-def _cool_ok(sym:str)->bool:
-    now=time.time(); last=_last.get(sym,0.0)
-    if now-last<COOL: return False
-    _last[sym]=now; return True
-def should_alert(ev: Dict[str, Any]):
-    sym=str(ev.get('symbol') or '').upper()
-    if not sym: return None
-    price=ev.get('price_usd'); chg=ev.get('change_pct'); vol=ev.get('volume24_usd'); liq=ev.get('liquidity_usd')
-    is_new=bool(ev.get('is_new_pair', False)); spike=ev.get('spike_pct')
-    if vol is not None and vol<MIN_VOLUME: return None
-    if liq is not None and liq<MIN_LIQ: return None
-    in_scope = sym in holdings or sym in traded or (is_new and spike is not None and spike>=SPIKE)
-    if not in_scope: return None
+from typing import Any, Dict, Optional, Set
+
+__all__ = [
+    "make_guards_from_env",
+    "configure_guards",
+    "mark_trade",
+    "set_holdings",
+    "should_alert",
+]
+
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "window_minutes": 60,
+    "pump_pct": 20.0,
+    "drop_pct": -12.0,
+    "trail_drop_pct": -8.0,
+    "min_volume": 0.0,
+    "min_liquidity": 0.0,
+    "spike_threshold": 8.0,
+    "cooldown_seconds": 30,
+}
+
+_CONFIG: Dict[str, Any] = dict(DEFAULT_CONFIG)
+_last: Dict[str, float] = {}
+peaks: Dict[str, float] = {}
+traded: Set[str] = set()
+holdings: Set[str] = set()
+
+
+def _to_float(value: Any, default: float) -> float:
+    try:
+        if isinstance(value, Decimal):
+            return float(value)
+        return float(str(value))
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def make_guards_from_env(env: os._Environ[str] | Dict[str, str] = os.environ) -> Dict[str, Any]:
+    """Return guard thresholds computed from the environment."""
+    cfg = dict(DEFAULT_CONFIG)
+
+    cfg["window_minutes"] = _to_int(env.get("GUARD_WINDOW_MIN"), cfg["window_minutes"])
+    cfg["pump_pct"] = _to_float(env.get("GUARD_PUMP_PCT"), cfg["pump_pct"])
+    cfg["drop_pct"] = _to_float(env.get("GUARD_DROP_PCT"), cfg["drop_pct"])
+    cfg["trail_drop_pct"] = _to_float(env.get("GUARD_TRAIL_DROP_PCT"), cfg["trail_drop_pct"])
+    cfg["min_volume"] = _to_float(env.get("MIN_VOLUME_FOR_ALERT"), cfg["min_volume"])
+    cfg["min_liquidity"] = _to_float(env.get("DISCOVER_MIN_LIQ_USD"), cfg["min_liquidity"])
+    cfg["spike_threshold"] = _to_float(env.get("SPIKE_THRESHOLD"), cfg["spike_threshold"])
+
+    cooldown_raw = env.get("ALERTS_INTERVAL_MINUTES")
+    if cooldown_raw:
+        minutes = _to_int(cooldown_raw, cfg["window_minutes"])
+        cfg["cooldown_seconds"] = max(10, minutes * 60)
+    else:
+        cfg["cooldown_seconds"] = DEFAULT_CONFIG["cooldown_seconds"]
+
+    return cfg
+
+
+def configure_guards(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Update the active guard configuration and return the applied values."""
+    global _CONFIG
+    applied = dict(DEFAULT_CONFIG)
+    if config:
+        for key, value in config.items():
+            if key in applied:
+                if key == "window_minutes":
+                    applied[key] = _to_int(value, applied[key])
+                elif key == "cooldown_seconds":
+                    applied[key] = max(1, _to_int(value, applied[key]))
+                else:
+                    applied[key] = _to_float(value, applied[key])
+    _CONFIG = applied
+    return dict(_CONFIG)
+
+
+def mark_trade(symbol: str, side: str) -> None:
+    traded.add((symbol or "").upper())
+
+
+def set_holdings(symbols: Set[str]) -> None:
+    global holdings
+    holdings = {s.upper() for s in (symbols or set())}
+
+
+def _cool_ok(sym: str) -> bool:
+    now = time.time()
+    last = _last.get(sym, 0.0)
+    cooldown = float(_CONFIG.get("cooldown_seconds", DEFAULT_CONFIG["cooldown_seconds"]))
+    if now - last < cooldown:
+        return False
+    _last[sym] = now
+    return True
+
+
+def should_alert(ev: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    sym = str(ev.get("symbol") or "").upper()
+    if not sym:
+        return None
+
+    price = ev.get("price_usd")
+    change_pct = ev.get("change_pct")
+    volume = ev.get("volume24_usd")
+    liquidity = ev.get("liquidity_usd")
+    is_new = bool(ev.get("is_new_pair", False))
+    spike = ev.get("spike_pct")
+
+    min_volume = float(_CONFIG.get("min_volume", DEFAULT_CONFIG["min_volume"]))
+    min_liq = float(_CONFIG.get("min_liquidity", DEFAULT_CONFIG["min_liquidity"]))
+    spike_threshold = float(_CONFIG.get("spike_threshold", DEFAULT_CONFIG["spike_threshold"]))
+    pump_pct = float(_CONFIG.get("pump_pct", DEFAULT_CONFIG["pump_pct"]))
+    drop_pct = float(_CONFIG.get("drop_pct", DEFAULT_CONFIG["drop_pct"]))
+    trail_drop_pct = float(_CONFIG.get("trail_drop_pct", DEFAULT_CONFIG["trail_drop_pct"]))
+
+    if volume is not None and _to_float(volume, 0.0) < min_volume:
+        return None
+    if liquidity is not None and _to_float(liquidity, 0.0) < min_liq:
+        return None
+
+    in_scope = sym in holdings or sym in traded or (
+        is_new and spike is not None and _to_float(spike, 0.0) >= spike_threshold
+    )
+    if not in_scope:
+        return None
+
     if price is not None:
-        pk=peaks.get(sym); 
-        if pk is None or price>pk: peaks[sym]=price
-    action=None
-    if chg is not None:
-        if chg>=GUARD_PUMP_PCT: action='BUY_MORE'
-        if chg<=GUARD_DROP_PCT: action='SELL'
+        try:
+            price_val = float(price)
+            peak = peaks.get(sym)
+            if peak is None or price_val > peak:
+                peaks[sym] = price_val
+        except (TypeError, ValueError):
+            pass
+
+    action: Optional[str] = None
+    if change_pct is not None:
+        try:
+            change_val = float(change_pct)
+        except (TypeError, ValueError):
+            change_val = 0.0
+        if change_val >= pump_pct:
+            action = "BUY_MORE"
+        elif change_val <= drop_pct:
+            action = "SELL"
+
     if action is None and price is not None:
-        pk=peaks.get(sym)
-        if pk and pk>0:
-            dd=(price-pk)/pk*100
-            if dd<=GUARD_TRAIL_DROP_PCT: action='SELL'
-    if not action or not _cool_ok(sym): return None
-    ev=dict(ev); ev['guard_action']=action; return ev
+        try:
+            price_val = float(price)
+            peak = peaks.get(sym)
+            if peak and peak > 0:
+                drawdown = (price_val - peak) / peak * 100
+                if drawdown <= trail_drop_pct:
+                    action = "SELL"
+        except (TypeError, ValueError):
+            pass
+
+    if not action or not _cool_ok(sym):
+        return None
+
+    enriched = dict(ev)
+    enriched["guard_action"] = action
+    return enriched

--- a/scripts/cordex_diag.py
+++ b/scripts/cordex_diag.py
@@ -229,7 +229,7 @@ def check_runtime_env() -> None:
     _set("runtime.env", True, info=runtime)
 
 
-def main(argv: List[str]) -> int:
+def main(argv: List[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
 
     check_runtime_env()
@@ -250,9 +250,10 @@ def main(argv: List[str]) -> int:
     return 0 if RESULT["ok"] else 1
 
 
-def cli() -> None:
-    raise SystemExit(main(sys.argv[1:]))
-
 
 if __name__ == "__main__":
-    pass
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Cordex diagnostics")
+    _ = ap.parse_args()
+    raise SystemExit(main())

--- a/scripts/dedent_repo.py
+++ b/scripts/dedent_repo.py
@@ -52,14 +52,22 @@ def process(path: pathlib.Path, write: bool = False):
         print(f"[WOULD_FIX] {path}")
     return True
 
-def main():
-    write = "--write" in sys.argv
+def main(argv: list[str] | None = None) -> int:
+    args = argv or sys.argv[1:]
+    write = "--write" in (args or [])
     changed = 0
     for p in iter_py_files():
         if process(p, write=write):
             changed += 1
-    print(f"\nSummary: {'fixed' if write else 'would fix'} {changed} file(s).")
+    status = "fixed" if write else "would fix"
+    print(f"\nSummary: {status} {changed} file(s).")
     return 0
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Dedent repo")
+    ap.add_argument("--write", action="store_true", help="Apply changes")
+    parsed = ap.parse_args()
+    cli_args = ["--write"] if parsed.write else []
+    raise SystemExit(main(cli_args))

--- a/scripts/rebuild_cost_basis.py
+++ b/scripts/rebuild_cost_basis.py
@@ -30,7 +30,7 @@ def _fmt_dec(v: Decimal) -> str:
     return f"{v:.6f}"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     # 1) Bulk rebuild (writes annotated entries per day + cost_basis.json)
     try:
         update_cost_basis()  # public bulk path; no args
@@ -72,9 +72,10 @@ def main() -> int:
     return 0
 
 
-def cli() -> None:
-    raise SystemExit(main())
-
 
 if __name__ == "__main__":
-    pass
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Rebuild FIFO cost basis")
+    _ = ap.parse_args()
+    raise SystemExit(main())

--- a/scripts/repo_health.py
+++ b/scripts/repo_health.py
@@ -95,7 +95,7 @@ def cycles(graph):
         if t not in ded: ded.add(t); uniq.append(c)
     return uniq
 
-def main():
+def main(argv: list[str] | None = None) -> int:
     idx, parsed, symbols, synerr = parse_all()
     graph, miss_mod, miss_sym, sidefx = analyze(idx, parsed, symbols)
     cyc = cycles(graph)
@@ -117,10 +117,12 @@ def main():
         lines.append("✅ No issues detected.")
     REPORT.write_text("\n".join(lines), encoding="utf-8")
     print("\n".join(lines))
-
-def cli() -> None:
-    raise SystemExit(main())
+    return 0
 
 
 if __name__ == "__main__":
-    pass
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Repo health report")
+    _ = ap.parse_args()
+    raise SystemExit(main())

--- a/scripts/snapshot_wallet.py
+++ b/scripts/snapshot_wallet.py
@@ -14,11 +14,11 @@ from core.holdings import get_wallet_snapshot, format_snapshot_lines
 from telegram.api import send_telegram
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> int:
     snapshot = get_wallet_snapshot()
     if not snapshot:
         print("No holdings.")
-        return
+        return 0
 
     text = "💰 Wallet Snapshot\n" + format_snapshot_lines(snapshot)
     print(text)
@@ -28,11 +28,12 @@ def main() -> None:
         send_telegram(text)
     except Exception as e:
         print(f"⚠️ Failed to send Telegram message: {e}", file=sys.stderr)
-
-
-def cli() -> None:
-    main()
+    return 0
 
 
 if __name__ == "__main__":
-    pass
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Snapshot wallet holdings")
+    _ = ap.parse_args()
+    raise SystemExit(main())

--- a/telegram/api.py
+++ b/telegram/api.py
@@ -36,11 +36,12 @@ def send_telegram(text: str, escape: bool = True) -> None:
     """High-level sender with safe chunking and MarkdownV2 escaping."""
     if not text:
         return
-    payload_text = escape_md_v2(text) if escape else text
-    for part in chunk(payload_text, 3800):
-        ok = _tg_send_raw(part, use_markdown=True)
+    parts = list(chunk(text, 3800))
+    for raw_part in parts:
+        payload = escape_md_v2(raw_part) if escape else raw_part
+        ok = _tg_send_raw(payload, use_markdown=escape)
         if not ok:
-            _tg_send_raw(part, use_markdown=False)
+            _tg_send_raw(raw_part, use_markdown=False)
 
 
 # Compatibility alias for legacy imports used across the codebase


### PR DESCRIPTION
## Summary
- add init_app/start_services lifecycle hooks in main.py to defer env, logging, and scheduler setup until runtime
- update ledger, guards, and rpc modules to expose lazy configuration helpers without import-time side effects
- ensure telegram formatting/sending escapes safely, add argparse-friendly script entrypoints, and introduce runtime smoke workflow

## Testing
- pytest *(fails: web3 pytest plugin missing ContractName in eth_typing)*

- [x] main.py has no side-effects on import (dotenv/tz/logging/schedule only in init_app/start_services)
- [x] reports/ledger: mkdir moved to ensure_ledger_dir(), called lazily
- [x] scheduler helpers present and not executed on import
- [x] core/guards & core/rpc read ENV lazily via helper functions
- [x] scripts have argparse stubs + __main__ guard
- [ ] runtime-smoke workflow passes

------
https://chatgpt.com/codex/tasks/task_e_68e3f56fb4e483239494729380c84056