### PR TITLE
fix(holdings): env fallback for wallet address

### DIFF
--- a/core/holdings.py
+++ b/core/holdings.py
@@ -14,6 +14,14 @@ from core.providers.etherscan_like import (
 from core.pricing import get_price_usd
 from core.rpc import get_native_balance
 
+def _env_addr() -> str:
+    """Return the first non-empty wallet address env var."""
+    for key in ("WALLET_ADDRESS", "WALLETADDRESS"):
+        value = os.getenv(key, "").strip()
+        if value:
+            return value
+    return ""
+
 
 def _map_from_env(key: str) -> Dict[str, str]:
     """Parse an env var like 'SYMA=0x1234,SYMB=0xabcd' into a dict."""
@@ -57,7 +65,7 @@ def _sanitize_snapshot(raw: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, An
 
 def get_wallet_snapshot(address: str | None = None) -> Dict[str, Dict[str, Optional[str]]]:
     """Build a snapshot of wallet holdings (CRO native + configured ERC-20 tokens)."""
-    address = (address or os.getenv("WALLET_ADDRESS") or "").strip()
+    address = (address or _env_addr()).strip()
     if not address:
         return {}
 
@@ -146,7 +154,7 @@ def holdings_snapshot() -> Dict[str, Dict[str, Any]]:
     """Return a sanitized snapshot dict suitable for formatting.
     Guarantees a CRO entry seeded from RPC, then merges with discovered data.
     """
-    address = (os.getenv("WALLET_ADDRESS") or "").strip()
+    address = _env_addr()
 
     # Seed CRO via RPC (never raise)
     cro_entry: Dict[str, Any] = {"qty": "0", "price_usd": None, "usd": None}


### PR DESCRIPTION
## Summary
- add a shared `_env_addr()` helper that accepts both `WALLET_ADDRESS` and `WALLETADDRESS`
- reuse the helper in the holdings snapshot functions so the wallet address is found regardless of env naming

## Testing
- PYTHONPATH=. python scripts/cordex_ping.py
- PYTHONPATH=. python -c "import main; print('import main OK')"
- PYTHONPATH=. python - <<'PY' from core.holdings import holdings_snapshot; import json; print(json.dumps(holdings_snapshot(), indent=2))


------
https://chatgpt.com/codex/tasks/task_e_68e4f5f814d08323bae6dbb25d69e234