### PR TITLE
fix(holdings): env fallback for wallet address

### DIFF
--- a/core/holdings.py
+++ b/core/holdings.py
@@ -15,7 +15,7 @@ from core.pricing import get_price_usd
 from core.rpc import get_native_balance
 
 def _env_addr() -> str:
-    """Return the first non-empty wallet address env var."""
+    """Return wallet address from env (supports WALLET_ADDRESS & WALLETADDRESS)."""
     for key in ("WALLET_ADDRESS", "WALLETADDRESS"):
         value = os.getenv(key, "").strip()
         if value:


### PR DESCRIPTION
## Summary
- clarify the holdings `_env_addr` helper to document support for both `WALLET_ADDRESS` and `WALLETADDRESS`
- confirm that holdings snapshots reuse `_env_addr` for consistent environment fallback

## Testing
- python scripts/cordex_ping.py
- python -c "import main; print('import main OK')"
- PYTHONPATH=. python - <<'PY'
from core.holdings import holdings_snapshot, get_wallet_snapshot, _env_addr
from core.pricing import get_price_usd
import json
addr = _env_addr()
print("ENV_ADDR:", addr)
print("CRO_PRICE:", get_price_usd("CRO"))
print("RAW_SNAPSHOT:", json.dumps(get_wallet_snapshot(addr), indent=2))
print("FINAL_SNAPSHOT:", json.dumps(holdings_snapshot(), indent=2))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e53208772883239acd7ce54cc984fe