### PR TITLE
OPS-011 (meta): smoke+tests triggers + ops report

### DIFF
--- a/.github/OPS_REPORT.md
+++ b/.github/OPS_REPORT.md
@@ -1,0 +1,16 @@
+# OPS Report — 2025-10-08 01:20:04 UTC
+
+## Workflows Triggered (best-effort)
+- `runtime-smoke.yml` on `main`: **Not triggered** — GitHub API access unavailable from execution environment.
+- `tests-manual.yml` on `main`: **Not triggered** — GitHub API access unavailable from execution environment.
+
+## Pull Requests Snapshot
+Unable to fetch pull request and check status data. The automated `render_pull_requests_markdown` step could not be executed because outbound network/API access is not available in this environment.
+
+| number | title | state | draft | merged | head | base | checks | updated_at |
+|--------|-------|-------|-------|--------|------|------|--------|------------|
+| *(no data)* | *(no data)* | *(no data)* | *(no data)* | *(no data)* | *(no data)* | *(no data)* | *(no data)* | *(no data)* |
+
+## Notes
+- Re-run this report from an environment with GitHub API access to populate the PR table.
+- Once access is available, re-trigger the runtime smoke and manual tests workflows on `main`.


### PR DESCRIPTION
## Summary
- attempt to trigger runtime smoke and manual test workflows for `main`
- add `.github/OPS_REPORT.md` capturing the latest CI/PR status snapshot

## Testing
- not run (reporting/ops change)


------
https://chatgpt.com/codex/tasks/task_e_68e5bc14b8f88323b4d8133fccab7aaa