### PR TITLE
PR-003P: Fix diag_holdings import path (PYTHONPATH + sys.path)

### DIFF
--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -8,6 +8,7 @@ jobs:
       TZ: Europe/Athens
       DRY_RUN: "1"
       DEBUG_HOLDINGS: "1"
+      PYTHONPATH: "."
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/diag_holdings.py
+++ b/scripts/diag_holdings.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""Diagnostics helper for wallet holdings snapshots."""
+
 import os
+import sys
 
 os.environ.setdefault("DEBUG_HOLDINGS", "1")
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
 from core.holdings import get_wallet_snapshot_debug
 
 


### PR DESCRIPTION
- Sets PYTHONPATH=. in runtime-smoke.yml so 'core' is importable.
- Adds sys.path insert guard to scripts/diag_holdings.py for local and CI environments.

------
https://chatgpt.com/codex/tasks/task_e_68e661f53a8c832392f2a71a22f9f638